### PR TITLE
switch intToTrits parameter type from int to int64_t to avoid integer overflow, leading to wrong computation

### DIFF
--- a/include/iota/types/trinary.hpp
+++ b/include/iota/types/trinary.hpp
@@ -74,8 +74,8 @@ Trits  trytesToTrits(const Trytes& trytes);
 Trytes tritsToTrytes(const Trits& trits);
 Trytes tritsToTrytes(const Trits& trits, unsigned int length);
 
-Types::Trits intToTrits(const int& value);
-Types::Trits intToTrits(const int& value, std::size_t length);
+Types::Trits intToTrits(const int64_t& value);
+Types::Trits intToTrits(const int64_t& value, std::size_t length);
 
 template <typename T>
 T

--- a/source/models/bundle.cpp
+++ b/source/models/bundle.cpp
@@ -86,13 +86,13 @@ Bundle::finalize(const std::shared_ptr<IOTA::Crypto::ISponge>& customSponge) {
     trx.setCurrentIndex(i);
     trx.setLastIndex(transactions_.size() - 1);
 
-    auto value = IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits((int)trx.getValue(), SeedLength));
+    auto value = IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits(trx.getValue(), SeedLength));
     auto timestamp = IOTA::Types::tritsToTrytes(
-        IOTA::Types::intToTrits((int)trx.getTimestamp(), TryteAlphabetLength));
+        IOTA::Types::intToTrits(trx.getTimestamp(), TryteAlphabetLength));
     auto currentIndex = IOTA::Types::tritsToTrytes(
-        IOTA::Types::intToTrits((int)trx.getCurrentIndex(), TryteAlphabetLength));
+        IOTA::Types::intToTrits(trx.getCurrentIndex(), TryteAlphabetLength));
     auto lastIndexTrits = IOTA::Types::tritsToTrytes(
-        IOTA::Types::intToTrits((int)trx.getLastIndex(), TryteAlphabetLength));
+        IOTA::Types::intToTrits(trx.getLastIndex(), TryteAlphabetLength));
 
     auto t = IOTA::Types::trytesToTrits(trx.getAddress() + value + trx.getTag() + timestamp +
                                         currentIndex + lastIndexTrits);

--- a/source/models/transaction.cpp
+++ b/source/models/transaction.cpp
@@ -274,19 +274,19 @@ Transaction::operator!=(Transaction rhs) const {
 
 std::string
 Transaction::toTrytes() const {
-  auto value = IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits((int)getValue(), SeedLength));
+  auto value = IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits(getValue(), SeedLength));
   auto timestamp =
-      IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits((int)getTimestamp(), TryteAlphabetLength));
-  auto currentIndex = IOTA::Types::tritsToTrytes(
-      IOTA::Types::intToTrits((int)getCurrentIndex(), TryteAlphabetLength));
+      IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits(getTimestamp(), TryteAlphabetLength));
+  auto currentIndex =
+      IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits(getCurrentIndex(), TryteAlphabetLength));
   auto lastIndex =
-      IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits((int)getLastIndex(), TryteAlphabetLength));
+      IOTA::Types::tritsToTrytes(IOTA::Types::intToTrits(getLastIndex(), TryteAlphabetLength));
   auto attachmentTimestamp = IOTA::Types::tritsToTrytes(
-      IOTA::Types::intToTrits((int)getAttachmentTimestamp(), TryteAlphabetLength));
+      IOTA::Types::intToTrits(getAttachmentTimestamp(), TryteAlphabetLength));
   auto attachmentTimestampLowerBound = IOTA::Types::tritsToTrytes(
-      IOTA::Types::intToTrits((int)getAttachmentTimestampLowerBound(), TryteAlphabetLength));
+      IOTA::Types::intToTrits(getAttachmentTimestampLowerBound(), TryteAlphabetLength));
   auto attachmentTimestampUpperBound = IOTA::Types::tritsToTrytes(
-      IOTA::Types::intToTrits((int)getAttachmentTimestampUpperBound(), TryteAlphabetLength));
+      IOTA::Types::intToTrits(getAttachmentTimestampUpperBound(), TryteAlphabetLength));
   auto tag = getTag().empty() ? getObsoleteTag() : getTag();
 
   return getSignatureFragments() + getAddress() + value + getObsoleteTag() + timestamp +

--- a/source/types/trinary.cpp
+++ b/source/types/trinary.cpp
@@ -122,9 +122,9 @@ tritsToTrytes(const Trits& trits, unsigned int length) {
 }
 
 Types::Trits
-intToTrits(const int& value) {
+intToTrits(const int64_t& value) {
   Types::Trits trits;
-  unsigned int absoluteValue = std::abs(value);
+  uint64_t     absoluteValue = std::abs(value);
 
   while (absoluteValue > 0) {
     int8_t remainder = absoluteValue % 3;
@@ -137,14 +137,16 @@ intToTrits(const int& value) {
 
     trits.push_back(remainder);
   }
+
   if (value < 0) {
     std::transform(std::begin(trits), std::end(trits), std::begin(trits), std::negate<int>());
   }
+
   return trits;
 }
 
 Types::Trits
-intToTrits(const int& value, std::size_t length) {
+intToTrits(const int64_t& value, std::size_t length) {
   auto res = intToTrits(value);
 
   res.resize(length, 0);

--- a/test/source/api/extended_test.cpp
+++ b/test/source/api/extended_test.cpp
@@ -433,7 +433,8 @@ TEST(Extended, TraverseBundleFullInvalidHash) {
   auto api    = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
   auto bundle = IOTA::Models::Bundle{};
 
-  EXPECT_THROW(api.traverseBundle("salut", "", bundle), IOTA::Errors::IllegalState);
+  EXPECT_EXCEPTION(api.traverseBundle("salut", "Invalid hashes input", bundle);
+                   , IOTA::Errors::BadRequest, "");
 }
 
 TEST(Extended, TraverseBundleFullInvalidBundleHash) {


### PR DESCRIPTION
This fix the invalid result of Transaction::toTrytes().
Just want to make sure you don't have any concern about this change.