### PR TITLE
Truncate addresses

### DIFF
--- a/include/iota/api/requests/get_balances.hpp
+++ b/include/iota/api/requests/get_balances.hpp
@@ -51,7 +51,7 @@ public:
   /**
    * full init ctor
    */
-  explicit GetBalances(const std::vector<std::string>& addresses = {}, const int& threshold = 0);
+  explicit GetBalances(const std::vector<Types::Trytes>& addresses = {}, const int& threshold = 0);
 
   /**
    * default dtor
@@ -97,7 +97,7 @@ private:
   /*
    * List of addresses you want to get the confirmed balance from.
    */
-  std::vector<std::string> addresses_;
+  std::vector<Types::Trytes> addresses_;
   /*
    * Confirmation threshold, should be set to 100.
    */

--- a/source/api/requests/find_transactions.cpp
+++ b/source/api/requests/find_transactions.cpp
@@ -24,6 +24,7 @@
 //
 
 #include <iota/api/requests/find_transactions.hpp>
+#include <iota/crypto/checksum.hpp>
 
 namespace IOTA {
 
@@ -46,6 +47,10 @@ FindTransactions::serialize(json& data) {
   Base::serialize(data);
 
   if (!addresses_.empty()) {
+    std::transform(std::begin(addresses_), std::end(addresses_), std::begin(addresses_),
+                   [](const Types::Trytes& address) -> Types::Trytes {
+                     return IOTA::Crypto::Checksum::remove(address);
+                   });
     data["addresses"] = addresses_;
   }
 

--- a/source/api/requests/get_balances.cpp
+++ b/source/api/requests/get_balances.cpp
@@ -24,6 +24,7 @@
 //
 
 #include <iota/api/requests/get_balances.hpp>
+#include <iota/crypto/checksum.hpp>
 
 namespace IOTA {
 
@@ -31,13 +32,17 @@ namespace API {
 
 namespace Requests {
 
-GetBalances::GetBalances(const std::vector<std::string>& addresses, const int& threshold)
+GetBalances::GetBalances(const std::vector<Types::Trytes>& addresses, const int& threshold)
     : Base("getBalances"), addresses_(addresses), threshold_(threshold) {
 }
 
 void
 GetBalances::serialize(json& data) {
   Base::serialize(data);
+  std::transform(std::begin(addresses_), std::end(addresses_), std::begin(addresses_),
+                 [](const Types::Trytes& address) -> Types::Trytes {
+                   return IOTA::Crypto::Checksum::remove(address);
+                 });
   data["addresses"] = addresses_;
   data["threshold"] = threshold_;
 }


### PR DESCRIPTION
As getBalances and findTransactions only accept addresses without their checksum, I propose to truncate them in their serialisation.