### PR TITLE
Fix GetAccountData

### DIFF
--- a/source/api/extended.cpp
+++ b/source/api/extended.cpp
@@ -287,6 +287,8 @@ Extended::bundlesFromAddresses(const std::vector<IOTA::Types::Trytes>& addresses
                                bool                                    withInclusionStates) const {
   //! find transactions for addresses
   const auto trxs = findTransactionObjects(addresses);
+  if (trxs.empty())
+    return {};
 
   //! filter tail/non tail transactions
   std::vector<IOTA::Types::Trytes> tailTransactions;


### PR DESCRIPTION
As we introduced exceptions from the service in a previous commit, calling findTransactionObjectsByBundle with an empty object raised an "Invalid parameters" exception.

I think there is no use to continue in bundlesFromAddresses as soon as we know there are no transactions for the given addresses.

I simply checked if there aren't any transactions, then returning empty Bundle.

Are you ok with this ?