### PR TITLE
Stop watch test improvement

### DIFF
--- a/test/source/utils/stop_watch_test.cpp
+++ b/test/source/utils/stop_watch_test.cpp
@@ -46,7 +46,8 @@ TEST(StopWatch, NowShouldReturnCurrentTime) {
   auto res = std::chrono::duration_cast<std::chrono::seconds>(s.now());
 
   //! there might be a little delay in ms, but switching to seconds should give same
-  EXPECT_EQ(current, res);
+  EXPECT_TRUE(current == res || current + std::chrono::seconds(1) == res)
+    << "Where current: " << current.count() << " and res: " << res.count();
 }
 
 TEST(StopWatch, NowShouldIncreaseOverTime) {

--- a/test/source/utils/stop_watch_test.cpp
+++ b/test/source/utils/stop_watch_test.cpp
@@ -57,7 +57,7 @@ TEST(StopWatch, NowShouldIncreaseOverTime) {
   auto res_after = std::chrono::duration_cast<std::chrono::seconds>(s.now());
 
   //! there might be a little delay in ms, but switching to seconds should give same
-  EXPECT_EQ(res_before + std::chrono::seconds(1), res_after);
+  EXPECT_LE(res_before + std::chrono::seconds(1), res_after);
 }
 
 TEST(StopWatch, RestartShouldRestartTimer) {


### PR DESCRIPTION
I think I ran exactly into this rare occasion in the build for commit 20a745afbccfc431c172f135dfa05507384ef52e in PR #214 where `std::this_thread::sleep_for` blocked a few milliseconds longer than a second and `res_before` was taken close to the start of the next second, such that `res_after` actually was taken in the second next second, thus failing the test.

Testing for less than or equal should be fine in this case, since `std::this_thread::sleep_for` is guaranteed to block for at least a second.

 A similar issue could occur in the `NowShouldReturnCurrentTime` test case, where the reference measurement may happen to be taken in the next second. Here, I simply changed the check to also accept the next second. Another option would be to accept a difference between `current` and `res` below a certain threshold in milliseconds.

What do you guys think?