### PR TITLE
create Model::Tag and use it in place of Types::Trytes

### DIFF
--- a/include/iota/api/core.hpp
+++ b/include/iota/api/core.hpp
@@ -37,6 +37,7 @@
 #include <iota/api/responses/get_trytes.hpp>
 #include <iota/api/responses/remove_neighbors.hpp>
 #include <iota/api/service.hpp>
+#include <iota/models/tag.hpp>
 
 namespace IOTA {
 
@@ -135,7 +136,7 @@ public:
    * @return The response.
    */
   Responses::FindTransactions findTransactions(const std::vector<Types::Trytes>& addresses,
-                                               const std::vector<Types::Trytes>& tags,
+                                               const std::vector<Models::Tag>&   tags,
                                                const std::vector<Types::Trytes>& approvees,
                                                const std::vector<Types::Trytes>& bundles) const;
 

--- a/include/iota/api/extended.hpp
+++ b/include/iota/api/extended.hpp
@@ -38,6 +38,7 @@
 #include <iota/api/responses/send_transfer.hpp>
 #include <iota/crypto/sponge_factory.hpp>
 #include <iota/models/bundle.hpp>
+#include <iota/models/tag.hpp>
 #include <iota/models/transfer.hpp>
 #include <iota/utils/stop_watch.hpp>
 
@@ -310,7 +311,7 @@ public:
    *
    * @return the list of transactions which contain the specified tag value.
    */
-  Responses::FindTransactions findTransactionsByTags(const std::vector<Types::Trytes>& tags) const;
+  Responses::FindTransactions findTransactionsByTags(const std::vector<Models::Tag>& tags) const;
 
   /**
    * Find the transactions which match the specified approvees.
@@ -367,7 +368,7 @@ public:
    * @param security           The security level of private key / seed.
    * @param inputs             List of inputs used for funding the transfer.
    * @param bundle             To be populated.
-   * @param unpadTag           The tag.
+   * @param tag                The tag. Must be of type Models::Tag or implicitly convertible to it.
    * @param totalValue         The total value.
    * @param remainderAddress   If defined, this address will be used for sending the remainder value
    * (of the inputs) to.
@@ -375,12 +376,15 @@ public:
    *
    * @return Vector of trytes.
    */
+  template <typename TagType>
   std::vector<Types::Trytes> addRemainder(
       const Types::Trytes& seed, const unsigned int& security,
-      const std::vector<Models::Input>& inputs, Models::Bundle& bundle,
-      const Types::Trytes& unpadTag, const int64_t& totalValue,
-      const Types::Trytes&              remainderAddress,
-      const std::vector<Types::Trytes>& signatureFragments) const;
+      const std::vector<Models::Input>& inputs, Models::Bundle& bundle, const TagType& tag,
+      const int64_t& totalValue, const Types::Trytes& remainderAddress,
+      const std::vector<Types::Trytes>& signatureFragments) const {
+    return addRemainderInternal(seed, security, inputs, bundle, Models::Tag{ tag }, totalValue,
+                                remainderAddress, signatureFragments);
+  }
 
   /**
    * Replays a transfer by doing Proof of Work again.
@@ -428,6 +432,25 @@ private:
 
   std::vector<Types::Trytes> signInputsAndReturn(
       const Types::Trytes& seed, const std::vector<Models::Input>& inputs, Models::Bundle& bundle,
+      const std::vector<Types::Trytes>& signatureFragments) const;
+
+  /**
+   * @param seed               Tryte-encoded seed.
+   * @param security           The security level of private key / seed.
+   * @param inputs             List of inputs used for funding the transfer.
+   * @param bundle             To be populated.
+   * @param tag                The tag.
+   * @param totalValue         The total value.
+   * @param remainderAddress   If defined, this address will be used for sending the remainder value
+   * (of the inputs) to.
+   * @param signatureFragments The signature fragments.
+   *
+   * @return Vector of trytes.
+   */
+  std::vector<Types::Trytes> addRemainderInternal(
+      const Types::Trytes& seed, const unsigned int& security,
+      const std::vector<Models::Input>& inputs, Models::Bundle& bundle, const Models::Tag& tag,
+      const int64_t& totalValue, const Types::Trytes& remainderAddress,
       const std::vector<Types::Trytes>& signatureFragments) const;
 
   /**

--- a/include/iota/api/requests/find_transactions.hpp
+++ b/include/iota/api/requests/find_transactions.hpp
@@ -28,6 +28,7 @@
 #include <json.hpp>
 
 #include <iota/api/requests/base.hpp>
+#include <iota/models/tag.hpp>
 #include <iota/types/trinary.hpp>
 
 using json = nlohmann::json;
@@ -60,7 +61,7 @@ public:
    * hash with 9's.
    */
   explicit FindTransactions(const std::vector<Types::Trytes>& addresses = {},
-                            const std::vector<Types::Trytes>& tags      = {},
+                            const std::vector<Models::Tag>&   tags      = {},
                             const std::vector<Types::Trytes>& approvees = {},
                             const std::vector<Types::Trytes>& bundles   = {});
 
@@ -97,17 +98,17 @@ public:
   /**
    * @return tags.
    */
-  const std::vector<Types::Trytes>& getTags() const;
+  const std::vector<Models::Tag>& getTags() const;
 
   /**
    * @return tags (non const version).
    */
-  std::vector<Types::Trytes>& getTags();
+  std::vector<Models::Tag>& getTags();
 
   /**
    * @param tags new tags for api call.
    */
-  void setTags(const std::vector<Types::Trytes>& tags);
+  void setTags(const std::vector<Models::Tag>& tags);
 
 public:
   /**
@@ -149,7 +150,7 @@ private:
   /**
    * List of transaction tags.
    */
-  std::vector<Types::Trytes> tags_;
+  std::vector<Models::Tag> tags_;
   /**
    * List of approvees of a transaction.
    */

--- a/include/iota/models/bundle.hpp
+++ b/include/iota/models/bundle.hpp
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include <iota/crypto/i_sponge.hpp>
+#include <iota/models/tag.hpp>
 #include <iota/models/transaction.hpp>
 
 namespace IOTA {
@@ -82,22 +83,12 @@ public:
 public:
   /**
    * Adds a bundle entry.
-   *
-   * @param signatureMessageLength Length of the signature message.
-   * @param address                The address.
-   * @param value                  The value.
-   * @param tag                    The tag.
-   * @param timestamp              The timestamp.
-   */
-  void addTransaction(int32_t signatureMessageLength, const Types::Trytes& address, int64_t value,
-                      const Types::Trytes& tag, int64_t timestamp);
-
-  /**
-   * Adds a bundle entry.
+   * If multiple signature fragments are required, generates as many transactions as necessary
    *
    * @param transaction Transaction to be added to the bundle.
+   * @param signatureMessageLength Length of the signature message.
    */
-  void addTransaction(const Transaction& transaction);
+  void addTransaction(const Transaction& transaction, int32_t signatureMessageLength = 1);
 
   /**
    * Finalizes the bundle using the specified curl implementation.

--- a/include/iota/models/tag.hpp
+++ b/include/iota/models/tag.hpp
@@ -1,0 +1,126 @@
+//
+// MIT License
+//
+// Copyright (c) 2017-2018 Thibault Martinez and Simon Ninon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+
+#pragma once
+
+#include <iota/types/trinary.hpp>
+
+namespace IOTA {
+
+namespace Models {
+
+class Tag {
+public:
+  /**
+   * Ctor.
+   *
+   * @param tag the tag value. Tag can be any valid tryte string not exceeding TagLength
+   */
+  Tag(const Types::Trytes& tag = "");
+
+  /**
+   * Default dtor.
+   */
+  ~Tag() = default;
+
+public:
+  /**
+   * @return tag as a trytes string, without any 9's padded. For example, tag 'ABC9999...' will
+   * return 'ABC'
+   */
+  const Types::Trytes& toTrytes() const;
+
+  /**
+   * @return tag as a trytes string, 9's right-padded to match the valid tag length. For example,
+   * tag 'ABC' will return 'ABC9999...'
+   */
+  const Types::Trytes& toTrytesWithPadding() const;
+
+  /**
+   * Set the tag value
+   *
+   * @param tag new value of the tag
+   */
+  void setTag(const Types::Trytes& tag);
+
+  /**
+   * @return whether the tag is empty or not. Please note that if your tag consists only of 9's, it
+   * will be considered empty as 9 is the padding character
+   */
+  bool empty() const;
+
+public:
+  /**
+   * Comparison operator.
+   *
+   * @param rhs other object to compare with.
+   *
+   * @return Whether the two transactions are equal or not.
+   */
+  bool operator==(const Tag& rhs) const;
+
+  /**
+   * Comparison operator.
+   *
+   * @param rhs other object to compare with.
+   *
+   * @return Whether the two transactions are equal or not.
+   */
+  bool operator!=(const Tag& rhs) const;
+
+public:
+  /**
+   * Comparison operator, trytes-based for convenient use
+   *
+   * @param rhs other object to compare with.
+   *
+   * @return Whether the two transactions are equal or not.
+   */
+  bool operator==(const Types::Trytes& rhs) const;
+
+  /**
+   * Comparison operator, trytes-based for convenient use
+   *
+   * @param rhs other object to compare with.
+   *
+   * @return Whether the two transactions are equal or not.
+   */
+  bool operator!=(const Types::Trytes& rhs) const;
+
+private:
+  /**
+   * tag value without padding
+   */
+  Types::Trytes tag_;
+
+  /**
+   * tag value with 9's right-padding
+   */
+  Types::Trytes paddedTag_;
+};
+
+}  // namespace Models
+
+}  // namespace IOTA

--- a/include/iota/models/tag.hpp
+++ b/include/iota/models/tag.hpp
@@ -31,6 +31,12 @@ namespace IOTA {
 
 namespace Models {
 
+/**
+ * Used to store transaction tags.
+ * Provides validity checks at construction / value set.
+ * Provides unpad and padded tag conversion.
+ * Any tags stored represented with this class are ensured to be valid.
+ */
 class Tag {
 public:
   /**

--- a/include/iota/models/transaction.hpp
+++ b/include/iota/models/transaction.hpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <utility>
 
+#include <iota/models/tag.hpp>
 #include <iota/types/trinary.hpp>
 
 namespace IOTA {
@@ -70,32 +71,64 @@ public:
    * @param address Address of the transaction.
    * @param value Value sent.
    * @param bundle Bundle hash.
-   * @param tag Tag of the transaction.
+   * @param tag Tag of the transaction. Must be a Models::Tag, or implicitly convertible to it.
    * @param attachmentTimestamp Attachment timestamp.
    * @param attachmentTimestampLowerBound Lower bound of the attachment timestamp.
    * @param attachmentTimestampUpperBound Index of the transaction in the bundle.
    */
+  template <typename TagType>
   Transaction(const Types::Trytes& signatureFragments, int64_t currentIndex, int64_t lastIndex,
               const Types::Trytes& nonce, const Types::Trytes& hash, int64_t timestamp,
               const Types::Trytes& trunkTransaction, const Types::Trytes& branchTransaction,
               const Types::Trytes& address, int64_t value, const Types::Trytes& bundle,
-              const Types::Trytes& tag, int64_t attachmentTimestamp,
-              int64_t attachmentTimestampLowerBound, int64_t attachmentTimestampUpperBound);
+              const TagType& tag, int64_t attachmentTimestamp,
+              int64_t attachmentTimestampLowerBound, int64_t attachmentTimestampUpperBound)
+      : hash_(hash),
+        signatureFragments_(signatureFragments),
+        address_(address),
+        value_(value),
+        tag_(tag),
+        obsoleteTag_(tag),
+        timestamp_(timestamp),
+        attachmentTimestamp_(attachmentTimestamp),
+        attachmentTimestampLowerBound_(attachmentTimestampLowerBound),
+        attachmentTimestampUpperBound_(attachmentTimestampUpperBound),
+        currentIndex_(currentIndex),
+        lastIndex_(lastIndex),
+        bundle_(bundle),
+        trunkTransaction_(trunkTransaction),
+        branchTransaction_(branchTransaction),
+        nonce_(nonce),
+        persistence_(false) {
+  }
 
   /**
    * Initializes a new instance of the Transaction class.
    *
    * @param address Address of the transaction.
    * @param value Value sent.
-   * @param tag Tag of the transaction.
+   * @param tag Tag of the transaction. Must be a Models::Tag, or implicitly convertible to it.
    * @param timestamp Timestamp at which transaction was issued.
    * @param attachmentTimestamp Attachment timestamp.
    * @param attachmentTimestampLowerBound Lower bound of the attachment timestamp.
    * @param attachmentTimestampUpperBound Index of the transaction in the bundle.
    */
-  Transaction(const Types::Trytes& address, int64_t value, const Types::Trytes& tag,
-              int64_t timestamp, int64_t attachmentTimestamp = 0,
-              int64_t attachmentTimestampLowerBound = 0, int64_t attachmentTimestampUpperBound = 0);
+  template <typename TagType>
+  Transaction(const Types::Trytes& address, int64_t value, const TagType& tag, int64_t timestamp,
+              int64_t attachmentTimestamp = 0, int64_t attachmentTimestampLowerBound = 0,
+              int64_t attachmentTimestampUpperBound = 0)
+      : address_(address),
+        value_(value),
+        tag_(tag),
+        obsoleteTag_(tag),
+        timestamp_(timestamp),
+        attachmentTimestamp_(attachmentTimestamp),
+        attachmentTimestampLowerBound_(attachmentTimestampLowerBound),
+        attachmentTimestampUpperBound_(attachmentTimestampUpperBound),
+        currentIndex_(0),
+        lastIndex_(0),
+        persistence_(false) {
+  }
 
 public:
   /**
@@ -163,10 +196,17 @@ public:
    *
    * @return The tag.
    */
-  const Types::Trytes& getTag() const;
+  const Models::Tag& getTag() const;
 
   /**
    * Set the tag.
+   *
+   * @param tag The tag.
+   */
+  void setTag(const Models::Tag& tag);
+
+  /**
+   * Set the tag, trytes-based for convenient use
    *
    * @param tag The tag.
    */
@@ -177,10 +217,17 @@ public:
    *
    * @return The obsolete tag.
    */
-  const Types::Trytes& getObsoleteTag() const;
+  const Models::Tag& getObsoleteTag() const;
 
   /**
    * Set the obsolete tag.
+   *
+   * @param tag The obsolete tag.
+   */
+  void setObsoleteTag(const Models::Tag& tag);
+
+  /**
+   * Set the obsolete tag, trytes-based for convenient use
    *
    * @param tag The obsolete tag.
    */
@@ -458,11 +505,11 @@ private:
   /**
    * Tag of the transaction.
    */
-  Types::Trytes tag_;
+  Models::Tag tag_;
   /**
    * Obsolete tag of the transaction.
    */
-  Types::Trytes obsoleteTag_;
+  Models::Tag obsoleteTag_;
   /**
    * Timestamp at which transaction was issued.
    */

--- a/include/iota/models/transfer.hpp
+++ b/include/iota/models/transfer.hpp
@@ -27,6 +27,7 @@
 
 #include <string>
 
+#include <iota/models/tag.hpp>
 #include <iota/types/trinary.hpp>
 
 namespace IOTA {
@@ -49,10 +50,13 @@ public:
    * @param address The address.
    * @param value The value.
    * @param message The message/
-   * @param tag The tag.
+   * @param tag The tag. Must be a Models::Tag object, or implicitly convertible to it.
    */
+  template <typename TagType>
   Transfer(const Types::Trytes& address, int64_t value, const Types::Trytes& message,
-           const Types::Trytes& tag);
+           const TagType& tag)
+      : address_(address), value_(value), message_(message), tag_(tag) {
+  }
 
   /**
    * Default dtor.
@@ -107,10 +111,17 @@ public:
    *
    * @return The tag.
    */
-  const Types::Trytes& getTag() const;
+  const Models::Tag& getTag() const;
 
   /**
    * Set the tag.
+   *
+   * @param tag The tag.
+   */
+  void setTag(const Models::Tag& tag);
+
+  /**
+   * Set the tag, tryte-based
    *
    * @param tag The tag.
    */
@@ -151,7 +162,7 @@ private:
   /**
    * The tag.
    */
-  Types::Trytes tag_;
+  Models::Tag tag_;
 };
 
 }  // namespace Models

--- a/source/api/core.cpp
+++ b/source/api/core.cpp
@@ -78,7 +78,7 @@ Core::getTips() const {
 
 Responses::FindTransactions
 Core::findTransactions(const std::vector<Types::Trytes>& addresses,
-                       const std::vector<Types::Trytes>& tags,
+                       const std::vector<Models::Tag>&   tags,
                        const std::vector<Types::Trytes>& approvees,
                        const std::vector<Types::Trytes>& bundles) const {
   //! skip request if no input, simply return empty
@@ -131,14 +131,17 @@ Core::attachToTangle(const Types::Trytes& trunkTransaction, const Types::Trytes&
     Types::Trytes              prevTx;
     for (auto& txTrytes : trytes) {
       auto tx = IOTA::Models::Transaction(txTrytes);
+
       tx.setTrunkTransaction(prevTx.empty() ? trunkTransaction : prevTx);
       tx.setBranchTransaction(prevTx.empty() ? branchTransaction : trunkTransaction);
-      if (tx.getTag().empty() || tx.getTag() == EmptyTag)
-        tx.setTag(tx.getObsoleteTag());
       tx.setAttachmentTimestamp(Utils::StopWatch::now().count());
       tx.setAttachmentTimestampLowerBound(0);
       tx.setAttachmentTimestampUpperBound(3812798742493L);
       tx.setNonce(pow(tx.toTrytes(), minWeightMagnitude));
+
+      if (tx.getTag().empty()) {
+        tx.setTag(tx.getObsoleteTag());
+      }
 
       resultTrytes.emplace_back(tx.toTrytes());
       prevTx = tx.getHash();

--- a/source/api/extended.cpp
+++ b/source/api/extended.cpp
@@ -382,7 +382,6 @@ Extended::prepareTransfers(const Types::Trytes& seed, int security,
   Models::Bundle             bundle;
   std::vector<Types::Trytes> signatureFragments;
   int64_t                    totalValue = 0;
-  Types::Trytes              tag;
 
   //  Iterate over all transfers, get totalValue
   //  and prepare the signatureFragments, message and tag
@@ -424,15 +423,10 @@ Extended::prepareTransfers(const Types::Trytes& seed, int security,
     // get current timestamp in seconds
     int64_t timestamp = Utils::StopWatch::now().count();
 
-    // If no tag defined, get 27 tryte tag.
-    tag = transfer.getTag().empty() ? "999999999999999999999999999" : transfer.getTag();
-
-    // Pad for required 27 tryte length
-    tag = Types::Utils::rightPad(tag, TryteAlphabetLength, '9');
-
     // Add first entry to the bundle
-    bundle.addTransaction(signatureMessageLength, transfer.getAddress(), transfer.getValue(), tag,
-                          timestamp);
+    bundle.addTransaction(
+        { transfer.getAddress(), transfer.getValue(), transfer.getTag(), timestamp },
+        signatureMessageLength);
     // Sum up total value
     totalValue += transfer.getValue();
   }
@@ -442,8 +436,8 @@ Extended::prepareTransfers(const Types::Trytes& seed, int security,
     //  Case 1: user provided inputs
     //  Validate the inputs by calling getBalances
     if (!validateInputs)
-      return addRemainder(seed, security, inputs, bundle, tag, totalValue, remainder,
-                          signatureFragments);
+      return addRemainder(seed, security, inputs, bundle, transfers.back().getTag(), totalValue,
+                          remainder, signatureFragments);
     if (!inputs.empty()) {
       // Get list if addresses of the provided inputs
       std::vector<Types::Trytes> inputsAddresses;
@@ -480,8 +474,8 @@ Extended::prepareTransfers(const Types::Trytes& seed, int security,
         throw Errors::IllegalState("Not enough balance");
       }
 
-      return addRemainder(seed, security, confirmedInputs, bundle, tag, totalValue, remainder,
-                          signatureFragments);
+      return addRemainder(seed, security, confirmedInputs, bundle, transfers.back().getTag(),
+                          totalValue, remainder, signatureFragments);
     }
 
     //  Case 2: Get inputs deterministically
@@ -491,8 +485,8 @@ Extended::prepareTransfers(const Types::Trytes& seed, int security,
     else {
       const auto newinputs = getInputs(seed, 0, 0, security, totalValue);
       // If inputs with enough balance
-      return addRemainder(seed, security, newinputs.getInputs(), bundle, tag, totalValue, remainder,
-                          signatureFragments);
+      return addRemainder(seed, security, newinputs.getInputs(), bundle, transfers.back().getTag(),
+                          totalValue, remainder, signatureFragments);
     }
   } else {
     // If no input required, don't sign and simply finalize the bundle
@@ -679,7 +673,7 @@ Extended::findTransactionsByAddresses(const std::vector<Types::Trytes>& addresse
 }
 
 Responses::FindTransactions
-Extended::findTransactionsByTags(const std::vector<Types::Trytes>& tags) const {
+Extended::findTransactionsByTags(const std::vector<Models::Tag>& tags) const {
   return findTransactions({}, tags, {}, {});
 }
 
@@ -737,20 +731,14 @@ Extended::findTailTransactionHash(const Types::Trytes& hash) const {
 }
 
 std::vector<Types::Trytes>
-Extended::addRemainder(const Types::Trytes& seed, const unsigned int& security,
-                       const std::vector<Models::Input>& inputs, Models::Bundle& bundle,
-                       const Types::Trytes& unpadTag, const int64_t& totalValue,
-                       const Types::Trytes&              remainderAddress,
-                       const std::vector<Types::Trytes>& signatureFragments) const {
+Extended::addRemainderInternal(const Types::Trytes& seed, const unsigned int& security,
+                               const std::vector<Models::Input>& inputs, Models::Bundle& bundle,
+                               const Models::Tag& tag, const int64_t& totalValue,
+                               const Types::Trytes&              remainderAddress,
+                               const std::vector<Types::Trytes>& signatureFragments) const {
   //! Validate the seed
   if (!Types::isValidTrytes(seed)) {
     throw Errors::IllegalState("Invalid Seed");
-  }
-
-  //! Validate the tag
-  auto tag = Types::Utils::rightPad(unpadTag, TagLength, '9');
-  if (!Types::isValidTrytes(tag)) {
-    throw Errors::IllegalState("Invalid Tag");
   }
 
   auto totalTransferValue = totalValue;
@@ -760,7 +748,7 @@ Extended::addRemainder(const Types::Trytes& seed, const unsigned int& security,
     auto    toSubtract  = -thisBalance;
     int64_t timestamp   = Utils::StopWatch::now().count();
     // Add input as bundle entry
-    bundle.addTransaction(input.getSecurity(), input.getAddress(), toSubtract, tag, timestamp);
+    bundle.addTransaction({ input.getAddress(), toSubtract, tag, timestamp }, input.getSecurity());
     // If there is a remainder value
     // Add extra output to send remaining funds to
     if (thisBalance >= totalTransferValue) {
@@ -769,14 +757,14 @@ Extended::addRemainder(const Types::Trytes& seed, const unsigned int& security,
       // Use it to send remaining funds to
       if (remainder > 0 && !remainderAddress.empty()) {
         // Remainder bundle entry
-        bundle.addTransaction(1, remainderAddress, remainder, tag, timestamp);
+        bundle.addTransaction({ remainderAddress, remainder, tag, timestamp });
         // Final function for signing inputs
         return signInputsAndReturn(seed, inputs, bundle, signatureFragments);
       } else if (remainder > 0) {
         // Generate a new Address by calling getNewAddress
         auto res = getNewAddresses(seed, 0, security, false, 0, false);
         // Remainder bundle entry
-        bundle.addTransaction(1, res.getAddresses()[0], remainder, tag, timestamp);
+        bundle.addTransaction({ res.getAddresses()[0], remainder, tag, timestamp });
         // Final function for signing inputs
         return signInputsAndReturn(seed, inputs, bundle, signatureFragments);
       } else {
@@ -819,16 +807,11 @@ std::vector<Models::Transaction>
 Extended::initiateTransfer(int securitySum, const Types::Trytes& inputAddress,
                            const Types::Trytes&           remainderAddress,
                            std::vector<Models::Transfer>& transfers) const {
-  //! If message or tag is not supplied, provide it
+  //! If message is not supplied, provide it
   //! Also remove the checksum of the address if it's there
-
   for (auto& transfer : transfers) {
     if (transfer.getMessage().empty()) {
       transfer.setMessage(Types::Utils::rightPad(transfer.getMessage(), 2187, '9'));
-    }
-
-    if (transfer.getTag().empty()) {
-      transfer.setTag(Types::Utils::rightPad(transfer.getTag(), 27, '9'));
     }
 
     if (!Types::isValidAddress(transfer.getAddress())) {
@@ -859,7 +842,6 @@ Extended::initiateTransfer(int securitySum, const Types::Trytes& inputAddress,
   Models::Bundle             bundle;
   int64_t                    totalValue = 0;
   std::vector<Types::Trytes> signatureFragments;
-  Types::Trytes              tag;
 
   //! Iterate over all transfers, get totalValue
   //! and prepare the signatureFragments, message and tag
@@ -896,12 +878,10 @@ Extended::initiateTransfer(int securitySum, const Types::Trytes& inputAddress,
     //! get current timestamp in seconds
     int64_t timestamp = Utils::StopWatch::now().count();
 
-    //! Pad for required TagLength tryte length
-    tag = Types::Utils::rightPad(transfer.getTag(), TagLength, '9');
-
     //! Add first entry to the bundle
-    bundle.addTransaction(signatureMessageLength, transfer.getAddress(), transfer.getValue(), tag,
-                          timestamp);
+    bundle.addTransaction(
+        { transfer.getAddress(), transfer.getValue(), transfer.getTag(), timestamp },
+        signatureMessageLength);
 
     //! Sum up total value
     totalValue += transfer.getValue();
@@ -928,7 +908,8 @@ Extended::initiateTransfer(int securitySum, const Types::Trytes& inputAddress,
 
     //! Add input as bundle entry
     //! Only a single entry, signatures will be added later
-    bundle.addTransaction(securitySum, inputAddress, toSubtract, tag, timestamp);
+    bundle.addTransaction({ inputAddress, toSubtract, transfers.back().getTag(), timestamp },
+                          securitySum);
   }
 
   //! Return not enough balance error
@@ -946,7 +927,7 @@ Extended::initiateTransfer(int securitySum, const Types::Trytes& inputAddress,
       throw Errors::IllegalState("No remainder address defined");
     }
 
-    bundle.addTransaction(1, remainderAddress, remainder, tag, timestamp);
+    bundle.addTransaction({ remainderAddress, remainder, transfers.back().getTag(), timestamp });
   }
 
   bundle.finalize(Crypto::create(cryptoType_));

--- a/source/api/requests/find_transactions.cpp
+++ b/source/api/requests/find_transactions.cpp
@@ -33,7 +33,7 @@ namespace API {
 namespace Requests {
 
 FindTransactions::FindTransactions(const std::vector<Types::Trytes>& addresses,
-                                   const std::vector<Types::Trytes>& tags,
+                                   const std::vector<Models::Tag>&   tags,
                                    const std::vector<Types::Trytes>& approvees,
                                    const std::vector<Types::Trytes>& bundles)
     : Base("findTransactions"),
@@ -54,7 +54,13 @@ FindTransactions::serialize(json& data) const {
   }
 
   if (!tags_.empty()) {
-    data["tags"] = tags_;
+    std::vector<Types::Trytes> tags;
+
+    for (const auto& tag : tags_) {
+      tags.push_back(tag.toTrytesWithPadding());
+    }
+
+    data["tags"] = tags;
   }
 
   if (!approvees_.empty()) {
@@ -81,18 +87,18 @@ FindTransactions::setAddresses(const std::vector<Types::Trytes>& addrs) {
   addresses_ = addrs;
 }
 
-const std::vector<Types::Trytes>&
+const std::vector<Models::Tag>&
 FindTransactions::getTags() const {
   return tags_;
 }
 
-std::vector<Types::Trytes>&
+std::vector<Models::Tag>&
 FindTransactions::getTags() {
   return tags_;
 }
 
 void
-FindTransactions::setTags(const std::vector<Types::Trytes>& tags) {
+FindTransactions::setTags(const std::vector<Models::Tag>& tags) {
   tags_ = tags;
 }
 

--- a/source/models/bundle.cpp
+++ b/source/models/bundle.cpp
@@ -60,16 +60,17 @@ Bundle::empty() const {
 }
 
 void
-Bundle::addTransaction(int32_t signatureMessageLength, const Types::Trytes& address, int64_t value,
-                       const Types::Trytes& tag, int64_t timestamp) {
-  for (int i = 0; i < signatureMessageLength; i++) {
-    transactions_.push_back({ address, i == 0 ? value : 0, tag, timestamp });
-  }
-}
-
-void
-Bundle::addTransaction(const Transaction& transaction) {
+Bundle::addTransaction(const Transaction& transaction, int32_t signatureMessageLength) {
   transactions_.push_back(transaction);
+
+  if (signatureMessageLength > 1) {
+    Transaction signatureTransaction = { transaction.getAddress(), 0, transaction.getTag(),
+                                         transaction.getTimestamp() };
+
+    for (int i = 1; i < signatureMessageLength; i++) {
+      transactions_.push_back(signatureTransaction);
+    }
+  }
 }
 
 void
@@ -94,8 +95,8 @@ Bundle::finalize(const std::shared_ptr<Crypto::ISponge>& customSponge) {
     auto lastIndexTrits =
         Types::tritsToTrytes(Types::intToTrits(trx.getLastIndex(), TryteAlphabetLength));
 
-    auto t = Types::trytesToTrits(trx.getAddress() + value + trx.getTag() + timestamp +
-                                  currentIndex + lastIndexTrits);
+    auto t = Types::trytesToTrits(trx.getAddress() + value + trx.getTag().toTrytesWithPadding() +
+                                  timestamp + currentIndex + lastIndexTrits);
 
     sponge->absorb(t);
   }

--- a/source/models/tag.cpp
+++ b/source/models/tag.cpp
@@ -23,81 +23,68 @@
 //
 //
 
+#include <string>
+
 #include <iota/constants.hpp>
-#include <iota/models/transfer.hpp>
+#include <iota/errors/illegal_state.hpp>
+#include <iota/models/tag.hpp>
+#include <iota/types/utils.hpp>
 
 namespace IOTA {
 
 namespace Models {
 
-const Types::Trytes&
-Transfer::getAddress() const {
-  return address_;
-}
-
-void
-Transfer::setAddress(const Types::Trytes& address) {
-  address_ = address;
-}
-
-int64_t
-Transfer::getValue() const {
-  return value_;
-}
-
-void
-Transfer::setValue(int64_t value) {
-  value_ = value;
+Tag::Tag(const Types::Trytes& tag) {
+  setTag(tag);
 }
 
 const Types::Trytes&
-Transfer::getMessage() const {
-  return message_;
-}
-
-void
-Transfer::setMessage(const Types::Trytes& message) {
-  message_ = message;
-}
-
-const Models::Tag&
-Transfer::getTag() const {
+Tag::toTrytes() const {
   return tag_;
 }
 
-void
-Transfer::setTag(const Models::Tag& tag) {
-  tag_ = tag;
+const Types::Trytes&
+Tag::toTrytesWithPadding() const {
+  return paddedTag_;
 }
 
 void
-Transfer::setTag(const Types::Trytes& tag) {
-  setTag(Models::Tag{ tag });
-}
-
-bool
-Transfer::isValid() const {
-  if (!Types::isValidAddress(getAddress())) {
-    return false;
+Tag::setTag(const Types::Trytes& tag) {
+  if (tag.length() > TagLength) {
+    throw Errors::IllegalState("tag is too long");
   }
 
-  // Check if message is correct trytes of any length
-  if (!Types::isValidTrytes(getMessage())) {
-    return false;
+  if (!Types::isValidTrytes(tag)) {
+    throw Errors::IllegalState("tag is not a valid trytes string");
   }
 
-  return true;
+  tag_       = tag.substr(0, tag.rfind('9'));
+  paddedTag_ = Types::Utils::rightPad(tag_, TagLength, '9');
 }
 
 bool
-Transfer::operator==(const Transfer& rhs) const {
-  return address_ == rhs.address_ && value_ == rhs.value_ && tag_ == rhs.tag_ &&
-         message_ == rhs.message_;
+Tag::empty() const {
+  return tag_.empty();
 }
 
 bool
-Transfer::operator!=(const Transfer& rhs) const {
+Tag::operator==(const Tag& rhs) const {
+  return tag_ == rhs.tag_;
+}
+
+bool
+Tag::operator!=(const Tag& rhs) const {
   return !operator==(rhs);
+}
+
+bool
+Tag::operator==(const Types::Trytes& rhs) const {
+  return operator==(Tag{ rhs });
+}
+
+bool
+Tag::operator!=(const Types::Trytes& rhs) const {
+  return operator!=(Tag{ rhs });
 }
 
 }  // namespace Models

--- a/source/models/tag.cpp
+++ b/source/models/tag.cpp
@@ -58,7 +58,12 @@ Tag::setTag(const Types::Trytes& tag) {
     throw Errors::IllegalState("tag is not a valid trytes string");
   }
 
-  tag_       = tag.substr(0, tag.rfind('9'));
+  int trailing9sPos = tag.length();
+  while (trailing9sPos > 0 && tag[trailing9sPos - 1] == '9') {
+    --trailing9sPos;
+  }
+
+  tag_       = tag.substr(0, trailing9sPos);
   paddedTag_ = Types::Utils::rightPad(tag_, TagLength, '9');
 }
 

--- a/source/models/transaction.cpp
+++ b/source/models/transaction.cpp
@@ -54,49 +54,6 @@ Transaction::Transaction(const Types::Trytes& trytes) {
   initFromTrytes(trytes);
 }
 
-Transaction::Transaction(const Types::Trytes& signatureFragments, int64_t currentIndex,
-                         int64_t lastIndex, const Types::Trytes& nonce, const Types::Trytes& hash,
-                         int64_t timestamp, const Types::Trytes& trunkTransaction,
-                         const Types::Trytes& branchTransaction, const Types::Trytes& address,
-                         int64_t value, const Types::Trytes& bundle, const Types::Trytes& tag,
-                         int64_t attachmentTimestamp, int64_t attachmentTimestampLowerBound,
-                         int64_t attachmentTimestampUpperBound)
-    : hash_(hash),
-      signatureFragments_(signatureFragments),
-      address_(address),
-      value_(value),
-      tag_(tag),
-      obsoleteTag_(tag),
-      timestamp_(timestamp),
-      attachmentTimestamp_(attachmentTimestamp),
-      attachmentTimestampLowerBound_(attachmentTimestampLowerBound),
-      attachmentTimestampUpperBound_(attachmentTimestampUpperBound),
-      currentIndex_(currentIndex),
-      lastIndex_(lastIndex),
-      bundle_(bundle),
-      trunkTransaction_(trunkTransaction),
-      branchTransaction_(branchTransaction),
-      nonce_(nonce),
-      persistence_(false) {
-}
-
-Transaction::Transaction(const Types::Trytes& address, int64_t value, const Types::Trytes& tag,
-                         int64_t timestamp, int64_t attachmentTimestamp,
-                         int64_t attachmentTimestampLowerBound,
-                         int64_t attachmentTimestampUpperBound)
-    : address_(address),
-      value_(value),
-      tag_(tag),
-      obsoleteTag_(tag),
-      timestamp_(timestamp),
-      attachmentTimestamp_(attachmentTimestamp),
-      attachmentTimestampLowerBound_(attachmentTimestampLowerBound),
-      attachmentTimestampUpperBound_(attachmentTimestampUpperBound),
-      currentIndex_(0),
-      lastIndex_(0),
-      persistence_(false) {
-}
-
 bool
 Transaction::isTailTransaction() const {
   return getCurrentIndex() == 0;
@@ -142,24 +99,34 @@ Transaction::setValue(int64_t value) {
   value_ = value;
 }
 
-const Types::Trytes&
+const Models::Tag&
 Transaction::getTag() const {
   return tag_;
 }
 
 void
-Transaction::setTag(const Types::Trytes& tag) {
+Transaction::setTag(const Models::Tag& tag) {
   tag_ = tag;
 }
 
-const Types::Trytes&
+void
+Transaction::setTag(const Types::Trytes& tag) {
+  setTag(Models::Tag{ tag });
+}
+
+const Models::Tag&
 Transaction::getObsoleteTag() const {
   return obsoleteTag_;
 }
 
 void
-Transaction::setObsoleteTag(const Types::Trytes& tag) {
+Transaction::setObsoleteTag(const Models::Tag& tag) {
   obsoleteTag_ = tag;
+}
+
+void
+Transaction::setObsoleteTag(const Types::Trytes& tag) {
+  setObsoleteTag(Models::Tag{ tag });
 }
 
 int64_t
@@ -297,10 +264,10 @@ Transaction::toTrytes() const {
       Types::intToTrits(getAttachmentTimestampUpperBound(), TryteAlphabetLength));
   auto tag = getTag().empty() ? getObsoleteTag() : getTag();
 
-  return getSignatureFragments() + getAddress() + value + getObsoleteTag() + timestamp +
-         currentIndex + lastIndex + getBundle() + getTrunkTransaction() + getBranchTransaction() +
-         tag + attachmentTimestamp + attachmentTimestampLowerBound + attachmentTimestampUpperBound +
-         getNonce();
+  return getSignatureFragments() + getAddress() + value + getObsoleteTag().toTrytesWithPadding() +
+         timestamp + currentIndex + lastIndex + getBundle() + getTrunkTransaction() +
+         getBranchTransaction() + tag.toTrytesWithPadding() + attachmentTimestamp +
+         attachmentTimestampLowerBound + attachmentTimestampUpperBound + getNonce();
 }
 
 void

--- a/test/source/api/core_test.cpp
+++ b/test/source/api/core_test.cpp
@@ -405,8 +405,8 @@ TEST(Core, AttachToTangleRemotePowOneTx) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port(), false);
 
   IOTA::Models::Bundle b;
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b.getTransactions()[0].toTrytes();
@@ -421,8 +421,8 @@ TEST(Core, AttachToTangleLocalPowOneTx) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port());
 
   IOTA::Models::Bundle b;
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b.getTransactions()[0].toTrytes();
@@ -437,14 +437,14 @@ TEST(Core, AttachToTangleRemotePowManyTx) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port(), false);
 
   IOTA::Models::Bundle b;
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b.getTransactions()[0].toTrytes();
@@ -459,14 +459,14 @@ TEST(Core, AttachToTangleLocalPowManyTx) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port());
 
   IOTA::Models::Bundle b;
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b.getTransactions()[0].toTrytes();

--- a/test/source/api/extended/add_remainder_test.cpp
+++ b/test/source/api/extended/add_remainder_test.cpp
@@ -122,7 +122,7 @@ TEST(Extended, AddRemainderInvalidTag) {
   EXPECT_EXCEPTION(
       api.addRemainder(ACCOUNT_1_SEED, 2, inputs, bundle, "hello", 100,
                        ACCOUNT_1_ADDRESS_2_HASH_WITHOUT_CHECKSUM, { EMPTY_SIGNATURE_FRAGMENT }),
-      IOTA::Errors::IllegalState, "Invalid Tag");
+      IOTA::Errors::IllegalState, "tag is not a valid trytes string");
 }
 
 TEST(Extended, AddRemainderTooShortTag) {

--- a/test/source/api/extended/initiate_transfer_test.cpp
+++ b/test/source/api/extended/initiate_transfer_test.cpp
@@ -423,7 +423,7 @@ TEST(Extended, InitiateTransferNoTransfer) {
                    IOTA::Errors::IllegalState, "Invalid value transfer");
 }
 
-TEST(Extended, PrepareTransfersInvalidTransferAddress) {
+TEST(Extended, InitiateTransfersInvalidTransferAddress) {
   auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
 
   auto transfer =
@@ -435,19 +435,7 @@ TEST(Extended, PrepareTransfersInvalidTransferAddress) {
                    IOTA::Errors::IllegalState, "Invalid transfer");
 }
 
-TEST(Extended, PrepareTransfersInvalidTransferTag) {
-  auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
-
-  auto transfer = IOTA::Models::Transfer{ ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM, 100, "TESTMSG",
-                                          "invalid__" };
-  auto transfers = std::vector<IOTA::Models::Transfer>{ transfer };
-
-  EXPECT_EXCEPTION(api.initiateTransfer(2, ACCOUNT_1_ADDRESS_1_HASH_WITHOUT_CHECKSUM,
-                                        ACCOUNT_1_ADDRESS_2_HASH_WITHOUT_CHECKSUM, transfers),
-                   IOTA::Errors::IllegalState, "Invalid transfer");
-}
-
-TEST(Extended, PrepareTransfersInvalidTransferMsg) {
+TEST(Extended, InitiateTransfersInvalidTransferMsg) {
   auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
 
   auto transfer  = IOTA::Models::Transfer{ ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM, 100,
@@ -459,7 +447,7 @@ TEST(Extended, PrepareTransfersInvalidTransferMsg) {
                    IOTA::Errors::IllegalState, "Invalid transfer");
 }
 
-TEST(Extended, PrepareTransfersNotEnoughFund) {
+TEST(Extended, InitiateTransfersNotEnoughFund) {
   auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
 
   auto transfer  = IOTA::Models::Transfer{ ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM,
@@ -472,7 +460,7 @@ TEST(Extended, PrepareTransfersNotEnoughFund) {
                    IOTA::Errors::IllegalState, "Not enough balance");
 }
 
-TEST(Extended, PrepareTransfersZeroTransfer) {
+TEST(Extended, InitiateTransfersZeroTransfer) {
   auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
 
   auto transfer  = IOTA::Models::Transfer{ ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM, 0, "TESTMSG",
@@ -499,7 +487,7 @@ TEST(Extended, InitiateTransferNoTag) {
   auto trx1 = res[0];
   EXPECT_EQ(trx1.getCurrentIndex(), 0);
   EXPECT_EQ(trx1.getLastIndex(), 3);
-  EXPECT_EQ(trx1.getTag(), "999999999999999999999999999");
+  EXPECT_EQ(trx1.getTag().toTrytesWithPadding(), "999999999999999999999999999");
   EXPECT_EQ(trx1.getNonce(), IOTA::EmptyNonce);
   EXPECT_EQ(trx1.getTrunkTransaction(), IOTA::EmptyHash);
   EXPECT_EQ(trx1.getBranchTransaction(), IOTA::EmptyHash);
@@ -539,7 +527,7 @@ TEST(Extended, InitiateTransferNoTag) {
   auto trx2 = res[1];
   EXPECT_EQ(trx2.getCurrentIndex(), 1);
   EXPECT_EQ(trx2.getLastIndex(), 3);
-  EXPECT_EQ(trx2.getTag(), "999999999999999999999999999");
+  EXPECT_EQ(trx2.getTag().toTrytesWithPadding(), "999999999999999999999999999");
   EXPECT_EQ(trx2.getNonce(), IOTA::EmptyNonce);
   EXPECT_EQ(trx2.getTrunkTransaction(), IOTA::EmptyHash);
   EXPECT_EQ(trx2.getBranchTransaction(), IOTA::EmptyHash);
@@ -554,7 +542,7 @@ TEST(Extended, InitiateTransferNoTag) {
   auto trx3 = res[2];
   EXPECT_EQ(trx3.getCurrentIndex(), 2);
   EXPECT_EQ(trx3.getLastIndex(), 3);
-  EXPECT_EQ(trx3.getTag(), "999999999999999999999999999");
+  EXPECT_EQ(trx3.getTag().toTrytesWithPadding(), "999999999999999999999999999");
   EXPECT_EQ(trx3.getNonce(), IOTA::EmptyNonce);
   EXPECT_EQ(trx3.getTrunkTransaction(), IOTA::EmptyHash);
   EXPECT_EQ(trx3.getBranchTransaction(), IOTA::EmptyHash);
@@ -569,7 +557,7 @@ TEST(Extended, InitiateTransferNoTag) {
   auto trx4 = res[3];
   EXPECT_EQ(trx4.getCurrentIndex(), 3);
   EXPECT_EQ(trx4.getLastIndex(), 3);
-  EXPECT_EQ(trx4.getTag(), "999999999999999999999999999");
+  EXPECT_EQ(trx4.getTag().toTrytesWithPadding(), "999999999999999999999999999");
   EXPECT_EQ(trx4.getNonce(), IOTA::EmptyNonce);
   EXPECT_EQ(trx4.getTrunkTransaction(), IOTA::EmptyHash);
   EXPECT_EQ(trx4.getBranchTransaction(), IOTA::EmptyHash);

--- a/test/source/api/extended/prepare_transfers_test.cpp
+++ b/test/source/api/extended/prepare_transfers_test.cpp
@@ -404,22 +404,6 @@ TEST(Extended, PrepareTransfersInvalidTransferAddress) {
                    IOTA::Errors::IllegalState, "Invalid Transfer");
 }
 
-TEST(Extended, PrepareTransfersInvalidTransferTag) {
-  auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
-
-  auto transfer = IOTA::Models::Transfer{ ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM, 100, "TESTMSG",
-                                          "invalid__" };
-  auto transfers = std::vector<IOTA::Models::Transfer>{ transfer };
-
-  auto input  = IOTA::Models::Input{ ACCOUNT_1_ADDRESS_1_HASH_WITHOUT_CHECKSUM,
-                                    ACCOUNT_1_ADDRESS_1_FUND, 0, 2 };
-  auto inputs = std::vector<IOTA::Models::Input>{ input };
-
-  EXPECT_EXCEPTION(api.prepareTransfers(ACCOUNT_1_SEED, 2, transfers,
-                                        ACCOUNT_1_ADDRESS_2_HASH_WITHOUT_CHECKSUM, inputs, true),
-                   IOTA::Errors::IllegalState, "Invalid Transfer");
-}
-
 TEST(Extended, PrepareTransfersInvalidTransferMsg) {
   auto api = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
 

--- a/test/source/api/extended/send_transfer_test.cpp
+++ b/test/source/api/extended/send_transfer_test.cpp
@@ -100,22 +100,6 @@ TEST(Extended, SendTransferInvalidTransferMessage) {
                    IOTA::Errors::IllegalState, "Invalid Transfer");
 }
 
-TEST(Extended, SendTransferInvalidTransferTag) {
-  IOTA::API::Extended api(get_proxy_host(), get_proxy_port(), true, 380);
-
-  IOTA::Models::Transfer transfer = { ACCOUNT_5_ADDRESS_2_HASH_WITHOUT_CHECKSUM, 42, "TESTMSG",
-                                      "invalid__" };
-  std::vector<IOTA::Models::Transfer> transfers = { transfer };
-
-  IOTA::Models::Input input = { ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM, ACCOUNT_5_ADDRESS_1_FUND,
-                                0, 2 };
-  std::vector<IOTA::Models::Input> inputs = { input };
-
-  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 2, 27, POW_LEVEL, transfers, inputs,
-                                    ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM),
-                   IOTA::Errors::IllegalState, "Invalid Transfer");
-}
-
 TEST(Extended, SendTransferNotEnoughFund) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port(), true, 380);
 

--- a/test/source/api/extended/send_trytes_test.cpp
+++ b/test/source/api/extended/send_trytes_test.cpp
@@ -57,8 +57,8 @@ TEST(Extended, SendTrytesOne) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
   IOTA::Models::Bundle b;
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx = b.getTransactions()[0].toTrytes();
@@ -69,14 +69,14 @@ TEST(Extended, SendTrytesMulti) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
   IOTA::Models::Bundle b;
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
-  b.addTransaction(1, IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
-                   IOTA::Utils::StopWatch::now().count());
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
+  b.addTransaction({ IOTA::Crypto::Checksum::remove(ACCOUNT_4_ADDRESS_1_HASH), 0, IOTA::EmptyTag,
+                     IOTA::Utils::StopWatch::now().count() });
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx0 = b.getTransactions()[0].toTrytes();

--- a/test/source/api/extended/traverse_bundle_test.cpp
+++ b/test/source/api/extended/traverse_bundle_test.cpp
@@ -235,7 +235,7 @@ TEST(Extended, TraverseBundleFullInvalidBundleHash) {
 
 TEST(Extended, TraverseBundleFullIntermediateTrxWithAppending) {
   auto api    = IOTA::API::Extended{ get_proxy_host(), get_proxy_port() };
-  auto bundle = IOTA::Models::Bundle{ { IOTA::Models::Transaction{ "address", 42, "tag", 21 } } };
+  auto bundle = IOTA::Models::Bundle{ { IOTA::Models::Transaction{ "address", 42, "TAG", 21 } } };
   auto res    = api.traverseBundle(BUNDLE_1_TRX_4_HASH, BUNDLE_1_HASH, bundle);
 
   EXPECT_EQ(res.getTransactions().size(), 2UL);
@@ -243,7 +243,7 @@ TEST(Extended, TraverseBundleFullIntermediateTrxWithAppending) {
   const auto& trx1 = res.getTransactions()[0];
   EXPECT_EQ(trx1.getAddress(), "address");
   EXPECT_EQ(trx1.getValue(), 42);
-  EXPECT_EQ(trx1.getTag(), "tag");
+  EXPECT_EQ(trx1.getTag(), "TAG");
   EXPECT_EQ(trx1.getTimestamp(), 21);
 
   const auto& trx2 = res.getTransactions()[1];

--- a/test/source/api/requests/find_transactions_test.cpp
+++ b/test/source/api/requests/find_transactions_test.cpp
@@ -29,54 +29,55 @@
 
 TEST(FindTransactionsRequest, CtorShouldInitFields) {
   const IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                                   { "tag1", "tag2" },
+                                                   { { "TAGONE" }, { "TAGTWO" } },
                                                    { "approvee1", "approvee2" },
                                                    { "bundle1", "bundle2" } };
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }
 
 TEST(FindTransactionsRequest, GetAddressesNonConst) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
   req.getAddresses().push_back("addr3");
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2", "addr3" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }
 
 TEST(FindTransactionsRequest, GetTagsNonConst) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
-  req.getTags().push_back("tag3");
+  req.getTags().push_back({ "TAGTHREE" });
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2", "tag3" }));
+  EXPECT_EQ(req.getTags(),
+            std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" }, { "TAGTHREE" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }
 
 TEST(FindTransactionsRequest, GetApproveesNonConst) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
   req.getApprovees().push_back("approvee3");
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(),
             std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2", "approvee3" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
@@ -84,14 +85,14 @@ TEST(FindTransactionsRequest, GetApproveesNonConst) {
 
 TEST(FindTransactionsRequest, GetBundlesNonConst) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
   req.getBundles().push_back("bundle3");
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(),
             std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2", "bundle3" }));
@@ -99,63 +100,63 @@ TEST(FindTransactionsRequest, GetBundlesNonConst) {
 
 TEST(FindTransactionsRequest, SetAddresses) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
   req.setAddresses({ "null1", "null2" });
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "null1", "null2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }
 
 TEST(FindTransactionsRequest, SetTags) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
-  req.setTags({ "null1", "null2" });
+  req.setTags({ { "NULLONE" }, { "NULLTWO" } });
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "null1", "null2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "NULLONE" }, { "NULLTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }
 
 TEST(FindTransactionsRequest, SetApprovees) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
   req.setApprovees({ "null1", "null2" });
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "null1", "null2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }
 
 TEST(FindTransactionsRequest, SetBundles) {
   IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                             { "tag1", "tag2" },
+                                             { { "TAGONE" }, { "TAGTWO" } },
                                              { "approvee1", "approvee2" },
                                              { "bundle1", "bundle2" } };
 
   req.setBundles({ "null1", "null2" });
 
   EXPECT_EQ(req.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(req.getTags(), std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(req.getTags(), std::vector<IOTA::Models::Tag>({ { "TAGONE" }, { "TAGTWO" } }));
   EXPECT_EQ(req.getApprovees(), std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(req.getBundles(), std::vector<IOTA::Types::Trytes>({ "null1", "null2" }));
 }
 
 TEST(FindTransactionsRequest, SerializeShouldInitJson) {
   const IOTA::API::Requests::FindTransactions req{ { "addr1", "addr2" },
-                                                   { "tag1", "tag2" },
+                                                   { { "TAGONE" }, { "TAGTWO" } },
                                                    { "approvee1", "approvee2" },
                                                    { "bundle1", "bundle2" } };
   json                                        data;
@@ -164,7 +165,8 @@ TEST(FindTransactionsRequest, SerializeShouldInitJson) {
 
   EXPECT_EQ(data["command"].get<std::string>(), "findTransactions");
   EXPECT_EQ(data["addresses"], std::vector<IOTA::Types::Trytes>({ "addr1", "addr2" }));
-  EXPECT_EQ(data["tags"], std::vector<IOTA::Types::Trytes>({ "tag1", "tag2" }));
+  EXPECT_EQ(data["tags"], std::vector<IOTA::Types::Trytes>(
+                              { "TAGONE999999999999999999999", "TAGTWO999999999999999999999" }));
   EXPECT_EQ(data["approvees"], std::vector<IOTA::Types::Trytes>({ "approvee1", "approvee2" }));
   EXPECT_EQ(data["bundles"], std::vector<IOTA::Types::Trytes>({ "bundle1", "bundle2" }));
 }

--- a/test/source/api/responses/get_account_data_test.cpp
+++ b/test/source/api/responses/get_account_data_test.cpp
@@ -39,17 +39,17 @@ TEST(GetAccountDataResponse, DefaultCtorShouldInitFields) {
 TEST(GetAccountDataResponse, CtorShouldInitFields) {
   const IOTA::API::Responses::GetAccountData res(
       { "addr_1", "addr_2", "addr_3" },
-      { IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }),
-        IOTA::Models::Bundle({ { "addr_trx2", 2, "tag_trx2", 2 } }),
-        IOTA::Models::Bundle({ { "addr_trx3", 3, "tag_trx3", 3 } }) },
+      { IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }),
+        IOTA::Models::Bundle({ { "addr_trx2", 2, "TAGTRXTWO", 2 } }),
+        IOTA::Models::Bundle({ { "addr_trx3", 3, "TAGTRXTHREE", 3 } }) },
       21, 42);
 
   EXPECT_EQ(res.getAddresses(), std::vector<IOTA::Types::Trytes>({ "addr_1", "addr_2", "addr_3" }));
   EXPECT_EQ(res.getTransfers(),
             std::vector<IOTA::Models::Bundle>(
-                { IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }),
-                  IOTA::Models::Bundle({ { "addr_trx2", 2, "tag_trx2", 2 } }),
-                  IOTA::Models::Bundle({ { "addr_trx3", 3, "tag_trx3", 3 } }) }));
+                { IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }),
+                  IOTA::Models::Bundle({ { "addr_trx2", 2, "TAGTRXTWO", 2 } }),
+                  IOTA::Models::Bundle({ { "addr_trx3", 3, "TAGTRXTHREE", 3 } }) }));
   EXPECT_EQ(res.getBalance(), 21);
   EXPECT_EQ(res.getDuration(), 42);
 }
@@ -57,11 +57,11 @@ TEST(GetAccountDataResponse, CtorShouldInitFields) {
 TEST(GetAccountDataResponse, GetTransfersNonConst) {
   IOTA::API::Responses::GetAccountData res;
 
-  res.getTransfers().push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }));
+  res.getTransfers().push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }));
 
   EXPECT_EQ(res.getAddresses(), std::vector<IOTA::Types::Trytes>{});
   EXPECT_EQ(res.getTransfers(), std::vector<IOTA::Models::Bundle>({ IOTA::Models::Bundle(
-                                    { { "addr_trx1", 1, "tag_trx1", 1 } }) }));
+                                    { { "addr_trx1", 1, "TAGTRXONE", 1 } }) }));
   EXPECT_EQ(res.getBalance(), 0);
   EXPECT_EQ(res.getDuration(), 0);
 }
@@ -70,12 +70,12 @@ TEST(GetAccountDataResponse, SetTransfers) {
   IOTA::API::Responses::GetAccountData res;
 
   std::vector<IOTA::Models::Bundle> transfers = res.getTransfers();
-  transfers.push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }));
+  transfers.push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }));
   res.setTransfers(transfers);
 
   EXPECT_EQ(res.getAddresses(), std::vector<IOTA::Types::Trytes>{});
   EXPECT_EQ(res.getTransfers(), std::vector<IOTA::Models::Bundle>({ IOTA::Models::Bundle(
-                                    { { "addr_trx1", 1, "tag_trx1", 1 } }) }));
+                                    { { "addr_trx1", 1, "TAGTRXONE", 1 } }) }));
   EXPECT_EQ(res.getBalance(), 0);
   EXPECT_EQ(res.getDuration(), 0);
 }

--- a/test/source/api/responses/get_bundle_test.cpp
+++ b/test/source/api/responses/get_bundle_test.cpp
@@ -35,25 +35,25 @@ TEST(GetBundleResponse, DefaultCtorShouldInitFields) {
 }
 
 TEST(GetBundleResponse, CtorShouldInitFields) {
-  const IOTA::API::Responses::GetBundle res({ { "addr_trx1", 1, "tag_trx1", 1 },
-                                              { "addr_trx2", 2, "tag_trx2", 2 },
-                                              { "addr_trx3", 3, "tag_trx3", 3 } },
+  const IOTA::API::Responses::GetBundle res({ { "addr_trx1", 1, "TAGTRXONE", 1 },
+                                              { "addr_trx2", 2, "TAGTRXTWO", 2 },
+                                              { "addr_trx3", 3, "TAGTRXTHREE", 3 } },
                                             42);
 
   EXPECT_EQ(res.getTransactions(),
-            std::vector<IOTA::Models::Transaction>({ { "addr_trx1", 1, "tag_trx1", 1 },
-                                                     { "addr_trx2", 2, "tag_trx2", 2 },
-                                                     { "addr_trx3", 3, "tag_trx3", 3 } }));
+            std::vector<IOTA::Models::Transaction>({ { "addr_trx1", 1, "TAGTRXONE", 1 },
+                                                     { "addr_trx2", 2, "TAGTRXTWO", 2 },
+                                                     { "addr_trx3", 3, "TAGTRXTHREE", 3 } }));
   EXPECT_EQ(res.getDuration(), 42);
 }
 
 TEST(GetBundleResponse, GetTransactionsNonConst) {
   IOTA::API::Responses::GetBundle res;
 
-  res.getTransactions().push_back({ "addr_trx1", 1, "tag_trx1", 1 });
+  res.getTransactions().push_back({ "addr_trx1", 1, "TAGTRXONE", 1 });
 
   EXPECT_EQ(res.getTransactions(),
-            std::vector<IOTA::Models::Transaction>({ { "addr_trx1", 1, "tag_trx1", 1 } }));
+            std::vector<IOTA::Models::Transaction>({ { "addr_trx1", 1, "TAGTRXONE", 1 } }));
   EXPECT_EQ(res.getDuration(), 0);
 }
 
@@ -61,10 +61,10 @@ TEST(GetBundleResponse, SetTransactions) {
   IOTA::API::Responses::GetBundle res;
 
   std::vector<IOTA::Models::Transaction> transactions = res.getTransactions();
-  transactions.push_back({ "addr_trx1", 1, "tag_trx1", 1 });
+  transactions.push_back({ "addr_trx1", 1, "TAGTRXONE", 1 });
   res.setTransactions(transactions);
 
   EXPECT_EQ(res.getTransactions(),
-            std::vector<IOTA::Models::Transaction>({ { "addr_trx1", 1, "tag_trx1", 1 } }));
+            std::vector<IOTA::Models::Transaction>({ { "addr_trx1", 1, "TAGTRXONE", 1 } }));
   EXPECT_EQ(res.getDuration(), 0);
 }

--- a/test/source/api/responses/get_transfers_test.cpp
+++ b/test/source/api/responses/get_transfers_test.cpp
@@ -36,26 +36,26 @@ TEST(GetTransfersResponse, DefaultCtorShouldInitFields) {
 
 TEST(GetTransfersResponse, CtorShouldInitFields) {
   const IOTA::API::Responses::GetTransfers res(
-      { IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }),
-        IOTA::Models::Bundle({ { "addr_trx2", 2, "tag_trx2", 2 } }),
-        IOTA::Models::Bundle({ { "addr_trx3", 3, "tag_trx3", 3 } }) },
+      { IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }),
+        IOTA::Models::Bundle({ { "addr_trx2", 2, "TAGTRXTWO", 2 } }),
+        IOTA::Models::Bundle({ { "addr_trx3", 3, "TAGTRXTHREE", 3 } }) },
       42);
 
   EXPECT_EQ(res.getTransfers(),
             std::vector<IOTA::Models::Bundle>(
-                { IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }),
-                  IOTA::Models::Bundle({ { "addr_trx2", 2, "tag_trx2", 2 } }),
-                  IOTA::Models::Bundle({ { "addr_trx3", 3, "tag_trx3", 3 } }) }));
+                { IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }),
+                  IOTA::Models::Bundle({ { "addr_trx2", 2, "TAGTRXTWO", 2 } }),
+                  IOTA::Models::Bundle({ { "addr_trx3", 3, "TAGTRXTHREE", 3 } }) }));
   EXPECT_EQ(res.getDuration(), 42);
 }
 
 TEST(GetTransfersResponse, GetTransfersNonConst) {
   IOTA::API::Responses::GetTransfers res;
 
-  res.getTransfers().push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }));
+  res.getTransfers().push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }));
 
   EXPECT_EQ(res.getTransfers(), std::vector<IOTA::Models::Bundle>({ IOTA::Models::Bundle(
-                                    { { "addr_trx1", 1, "tag_trx1", 1 } }) }));
+                                    { { "addr_trx1", 1, "TAGTRXONE", 1 } }) }));
   EXPECT_EQ(res.getDuration(), 0);
 }
 
@@ -63,10 +63,10 @@ TEST(GetTransfersResponse, SetTransfers) {
   IOTA::API::Responses::GetTransfers res;
 
   std::vector<IOTA::Models::Bundle> transfers = res.getTransfers();
-  transfers.push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "tag_trx1", 1 } }));
+  transfers.push_back(IOTA::Models::Bundle({ { "addr_trx1", 1, "TAGTRXONE", 1 } }));
   res.setTransfers(transfers);
 
   EXPECT_EQ(res.getTransfers(), std::vector<IOTA::Models::Bundle>({ IOTA::Models::Bundle(
-                                    { { "addr_trx1", 1, "tag_trx1", 1 } }) }));
+                                    { { "addr_trx1", 1, "TAGTRXONE", 1 } }) }));
   EXPECT_EQ(res.getDuration(), 0);
 }

--- a/test/source/models/bundle_test.cpp
+++ b/test/source/models/bundle_test.cpp
@@ -34,37 +34,37 @@ TEST(Bundle, CtorDefault) {
 }
 
 TEST(Bundle, CtorFull) {
-  IOTA::Models::Bundle b({ { "addr", 0, "tag", 0 } });
+  IOTA::Models::Bundle b({ { "addr", 0, "TAG", 0 } });
 
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{
-                                     IOTA::Models::Transaction("addr", 0, "tag", 0) });
+                                     IOTA::Models::Transaction("addr", 0, "TAG", 0) });
 }
 
 TEST(Bundle, ConstGetters) {
-  const IOTA::Models::Bundle b({ { "addr", 0, "tag", 0 } });
+  const IOTA::Models::Bundle b({ { "addr", 0, "TAG", 0 } });
 
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{
-                                     IOTA::Models::Transaction("addr", 0, "tag", 0) });
+                                     IOTA::Models::Transaction("addr", 0, "TAG", 0) });
 }
 
 TEST(Bundle, TransactionsGetterAndSetter) {
   IOTA::Models::Bundle b;
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{});
 
-  b.addTransaction({ "addr", 0, "tag", 0 });
+  b.addTransaction({ "addr", 0, "TAG", 0 });
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{
-                                     IOTA::Models::Transaction("addr", 0, "tag", 0) });
+                                     IOTA::Models::Transaction("addr", 0, "TAG", 0) });
 }
 
 TEST(Bundle, TransactionsGetterAndSetterEmplace) {
   IOTA::Models::Bundle b;
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{});
 
-  b.addTransaction(3, "addr", 42, "tag", 21);
+  b.addTransaction({ "addr", 42, "TAG", 21 }, 3);
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>(
-                                     { IOTA::Models::Transaction("addr", 42, "tag", 21),
-                                       IOTA::Models::Transaction("addr", 0, "tag", 0),
-                                       IOTA::Models::Transaction("addr", 0, "tag", 0) }));
+                                     { IOTA::Models::Transaction("addr", 42, "TAG", 21),
+                                       IOTA::Models::Transaction("addr", 0, "TAG", 0),
+                                       IOTA::Models::Transaction("addr", 0, "TAG", 0) }));
 }
 
 TEST(Bundle, TransactionsNonConstGetter) {
@@ -72,14 +72,14 @@ TEST(Bundle, TransactionsNonConstGetter) {
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{});
 
   auto& trx = b.getTransactions();
-  trx.push_back({ "addr", 0, "tag", 0 });
+  trx.push_back({ "addr", 0, "TAG", 0 });
 
   EXPECT_EQ(b.getTransactions(), std::vector<IOTA::Models::Transaction>{
-                                     IOTA::Models::Transaction("addr", 0, "tag", 0) });
+                                     IOTA::Models::Transaction("addr", 0, "TAG", 0) });
 }
 
 TEST(Bundle, IsEmptyWithCtor) {
-  IOTA::Models::Bundle b({ { "addr", 0, "tag", 0 } });
+  IOTA::Models::Bundle b({ { "addr", 0, "TAG", 0 } });
   EXPECT_EQ(b.empty(), false);
 }
 
@@ -92,7 +92,7 @@ TEST(Bundle, IsEmptyWithAdd) {
   IOTA::Models::Bundle b;
   EXPECT_EQ(b.empty(), true);
 
-  b.addTransaction({ "addr", 0, "tag", 0 });
+  b.addTransaction({ "addr", 0, "TAG", 0 });
   EXPECT_EQ(b.empty(), false);
 }
 
@@ -101,12 +101,12 @@ TEST(Bundle, IsEmptyWithPush) {
   EXPECT_EQ(b.empty(), true);
 
   auto& trx = b.getTransactions();
-  trx.push_back({ "addr", 0, "tag", 0 });
+  trx.push_back({ "addr", 0, "TAG", 0 });
   EXPECT_EQ(b.empty(), false);
 }
 
 TEST(Bundle, GetLengthWithCtor) {
-  IOTA::Models::Bundle b({ { "addr", 0, "tag", 0 } });
+  IOTA::Models::Bundle b({ { "addr", 0, "TAG", 0 } });
   EXPECT_EQ(b.getLength(), 1UL);
 }
 
@@ -119,7 +119,7 @@ TEST(Bundle, GetLengthWithAdd) {
   IOTA::Models::Bundle b;
   EXPECT_EQ(b.getLength(), 0UL);
 
-  b.addTransaction({ "addr", 0, "tag", 0 });
+  b.addTransaction({ "addr", 0, "TAG", 0 });
   EXPECT_EQ(b.getLength(), 1UL);
 }
 
@@ -128,15 +128,15 @@ TEST(Bundle, GetLengthWithPush) {
   EXPECT_EQ(b.getLength(), 0UL);
 
   auto& trx = b.getTransactions();
-  trx.push_back({ "addr", 0, "tag", 0 });
+  trx.push_back({ "addr", 0, "TAG", 0 });
   EXPECT_EQ(b.getLength(), 1UL);
 }
 
 TEST(Bundle, EqOperator) {
   IOTA::Models::Bundle eq_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle eq_rhs(
-      { { "addr", 0, "tag", 9, 2, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 2, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
 
   eq_lhs.getTransactions()[0].setBundle("eq");
   eq_rhs.getTransactions()[0].setBundle("eq");
@@ -144,9 +144,9 @@ TEST(Bundle, EqOperator) {
   EXPECT_EQ(eq_lhs == eq_rhs, true);
 
   IOTA::Models::Bundle neq_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle neq_rhs(
-      { { "addr", 0, "tag", 9, 0, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 0, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
 
   neq_lhs.getTransactions()[0].setBundle("eq");
   neq_rhs.getTransactions()[0].setBundle("neq");
@@ -156,9 +156,9 @@ TEST(Bundle, EqOperator) {
 
 TEST(Bundle, NeqOperator) {
   IOTA::Models::Bundle eq_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle eq_rhs(
-      { { "addr", 0, "tag", 9, 2, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 2, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
 
   eq_lhs.getTransactions()[0].setBundle("eq");
   eq_rhs.getTransactions()[0].setBundle("eq");
@@ -166,9 +166,9 @@ TEST(Bundle, NeqOperator) {
   EXPECT_EQ(eq_lhs != eq_rhs, false);
 
   IOTA::Models::Bundle neq_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle neq_rhs(
-      { { "addr", 0, "tag", 9, 0, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 0, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
 
   neq_lhs.getTransactions()[0].setBundle("eq");
   neq_rhs.getTransactions()[0].setBundle("neq");
@@ -178,41 +178,41 @@ TEST(Bundle, NeqOperator) {
 
 TEST(Bundle, LtOperator) {
   IOTA::Models::Bundle eq_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle eq_rhs(
-      { { "addr", 0, "tag", 9, 2, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 2, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
   EXPECT_EQ(eq_lhs < eq_rhs, false);
 
   IOTA::Models::Bundle lt_lhs(
-      { { "addr", 0, "tag", 1, 0, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 0, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle lt_rhs(
-      { { "addr", 0, "tag", 9, 2, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 2, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
   EXPECT_EQ(lt_lhs < lt_rhs, true);
 
   IOTA::Models::Bundle gt_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle gt_rhs(
-      { { "addr", 0, "tag", 9, 0, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 0, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
   EXPECT_EQ(gt_lhs < gt_rhs, false);
 }
 
 TEST(Bundle, GtOperator) {
   IOTA::Models::Bundle eq_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle eq_rhs(
-      { { "addr", 0, "tag", 9, 2, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 2, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
   EXPECT_EQ(eq_lhs > eq_rhs, false);
 
   IOTA::Models::Bundle lt_lhs(
-      { { "addr", 0, "tag", 1, 0, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 0, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle lt_rhs(
-      { { "addr", 0, "tag", 9, 2, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 2, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
   EXPECT_EQ(lt_lhs > lt_rhs, false);
 
   IOTA::Models::Bundle gt_lhs(
-      { { "addr", 0, "tag", 1, 2, 3, 4 }, { "addr", 0, "tag", 5, 6, 7, 8 } });
+      { { "addr", 0, "TAG", 1, 2, 3, 4 }, { "addr", 0, "TAG", 5, 6, 7, 8 } });
   IOTA::Models::Bundle gt_rhs(
-      { { "addr", 0, "tag", 9, 0, 10, 11 }, { "addr", 0, "tag", 12, 13, 14, 16 } });
+      { { "addr", 0, "TAG", 9, 0, 10, 11 }, { "addr", 0, "TAG", 12, 13, 14, 16 } });
   EXPECT_EQ(gt_lhs > gt_rhs, true);
 }
 
@@ -307,9 +307,9 @@ TEST(Bundle, AddTrytes) {
   IOTA::Models::Bundle b;
 
   //! add 3 transactions
-  b.addTransaction({ "address", 1, "tag", 2 });
-  b.addTransaction({ "address", 1, "tag", 2 });
-  b.addTransaction({ "address", 1, "tag", 2 });
+  b.addTransaction({ "address", 1, "TAG", 2 });
+  b.addTransaction({ "address", 1, "TAG", 2 });
+  b.addTransaction({ "address", 1, "TAG", 2 });
 
   //! addTrytes testing different cases:
   //!  * padding

--- a/test/source/models/tag_test.cpp
+++ b/test/source/models/tag_test.cpp
@@ -1,0 +1,125 @@
+//
+// MIT License
+//
+// Copyright (c) 2017-2018 Thibault Martinez and Simon Ninon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+
+#include <gtest/gtest.h>
+
+#include <iota/errors/illegal_state.hpp>
+#include <iota/models/tag.hpp>
+#include <test/utils/expect_exception.hpp>
+
+TEST(Tag, FromCtor) {
+  IOTA::Models::Tag tagEmptyCtor;
+  EXPECT_EQ(tagEmptyCtor.empty(), true);
+  EXPECT_EQ(tagEmptyCtor.toTrytes(), "");
+  EXPECT_EQ(tagEmptyCtor.toTrytesWithPadding(), "999999999999999999999999999");
+
+  IOTA::Models::Tag tagFullValidTag("9ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(tagFullValidTag.empty(), false);
+  EXPECT_EQ(tagFullValidTag.toTrytes(), "9ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(tagFullValidTag.toTrytesWithPadding(), "9ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+  IOTA::Models::Tag tagShortTag("ABC");
+  EXPECT_EQ(tagShortTag.empty(), false);
+  EXPECT_EQ(tagShortTag.toTrytes(), "ABC");
+  EXPECT_EQ(tagShortTag.toTrytesWithPadding(), "ABC999999999999999999999999");
+
+  IOTA::Models::Tag tagTrailing9s("ABC999");
+  EXPECT_EQ(tagTrailing9s.empty(), false);
+  EXPECT_EQ(tagTrailing9s.toTrytes(), "ABC");
+  EXPECT_EQ(tagTrailing9s.toTrytesWithPadding(), "ABC999999999999999999999999");
+
+  EXPECT_EXCEPTION(IOTA::Models::Tag tagTooLongTag("9ABCDEFGHIJKLMNOPQRSTUVWXYZZ"),
+                   IOTA::Errors::IllegalState, "tag is too long");
+
+  EXPECT_EXCEPTION(IOTA::Models::Tag tagInvalid("9ABCDEFGHIJKLMNOPQRSTUVWXY8"),
+                   IOTA::Errors::IllegalState, "tag is not a valid trytes string");
+}
+
+TEST(Tag, FromSetter) {
+  IOTA::Models::Tag tag;
+
+  tag.setTag("");
+  EXPECT_EQ(tag.empty(), true);
+  EXPECT_EQ(tag.toTrytes(), "");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "999999999999999999999999999");
+
+  tag.setTag("9ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(tag.empty(), false);
+  EXPECT_EQ(tag.toTrytes(), "9ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "9ABCDEFGHIJKLMNOPQRSTUVWXYZ");
+
+  tag.setTag("ABC");
+  EXPECT_EQ(tag.empty(), false);
+  EXPECT_EQ(tag.toTrytes(), "ABC");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "ABC999999999999999999999999");
+
+  tag.setTag("ABC999");
+  EXPECT_EQ(tag.empty(), false);
+  EXPECT_EQ(tag.toTrytes(), "ABC");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "ABC999999999999999999999999");
+
+  EXPECT_EXCEPTION(tag.setTag("9ABCDEFGHIJKLMNOPQRSTUVWXYZZ"), IOTA::Errors::IllegalState,
+                   "tag is too long");
+  //! keeps previous value
+  EXPECT_EQ(tag.empty(), false);
+  EXPECT_EQ(tag.toTrytes(), "ABC");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "ABC999999999999999999999999");
+
+  EXPECT_EXCEPTION(tag.setTag("9ABCDEFGHIJKLMNOPQRSTUVWXY8"), IOTA::Errors::IllegalState,
+                   "tag is not a valid trytes string");
+  //! keeps previous value
+  EXPECT_EQ(tag.empty(), false);
+  EXPECT_EQ(tag.toTrytes(), "ABC");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "ABC999999999999999999999999");
+}
+
+TEST(Tag, ImplicitConversion) {
+  std::string       tagStr = "ABC999";
+  IOTA::Models::Tag tag    = tagStr;
+
+  EXPECT_EQ(tag.empty(), false);
+  EXPECT_EQ(tag.toTrytes(), "ABC");
+  EXPECT_EQ(tag.toTrytesWithPadding(), "ABC999999999999999999999999");
+}
+
+TEST(Tag, OperatorEq) {
+  IOTA::Models::Tag lhs_eq("TAG");
+  IOTA::Models::Tag rhs_eq("TAG999");
+  EXPECT_TRUE(lhs_eq == rhs_eq);
+
+  IOTA::Models::Tag lhs_neq("TAGONE");
+  IOTA::Models::Tag rhs_neq("TAGTWO999");
+  EXPECT_FALSE(lhs_neq == rhs_neq);
+}
+
+TEST(Tag, OperatorNEq) {
+  IOTA::Models::Tag lhs_eq("TAG");
+  IOTA::Models::Tag rhs_eq("TAG999");
+  EXPECT_FALSE(lhs_eq != rhs_eq);
+
+  IOTA::Models::Tag lhs_neq("TAGONE");
+  IOTA::Models::Tag rhs_neq("TAGTWO999");
+  EXPECT_TRUE(lhs_neq != rhs_neq);
+}

--- a/test/source/models/tag_test.cpp
+++ b/test/source/models/tag_test.cpp
@@ -123,3 +123,23 @@ TEST(Tag, OperatorNEq) {
   IOTA::Models::Tag rhs_neq("TAGTWO999");
   EXPECT_TRUE(lhs_neq != rhs_neq);
 }
+
+TEST(Tag, OperatorEqTrytes) {
+  IOTA::Models::Tag   lhs_eq("TAG");
+  IOTA::Types::Trytes rhs_eq("TAG999");
+  EXPECT_TRUE(lhs_eq == rhs_eq);
+
+  IOTA::Models::Tag   lhs_neq("TAGONE");
+  IOTA::Types::Trytes rhs_neq("TAGTWO999");
+  EXPECT_FALSE(lhs_neq == rhs_neq);
+}
+
+TEST(Tag, OperatorNEqTrytes) {
+  IOTA::Models::Tag   lhs_eq("TAG");
+  IOTA::Types::Trytes rhs_eq("TAG999");
+  EXPECT_FALSE(lhs_eq != rhs_eq);
+
+  IOTA::Models::Tag   lhs_neq("TAGONE");
+  IOTA::Types::Trytes rhs_neq("TAGTWO999");
+  EXPECT_TRUE(lhs_neq != rhs_neq);
+}

--- a/test/source/models/transaction_test.cpp
+++ b/test/source/models/transaction_test.cpp
@@ -222,20 +222,21 @@ TEST(Transaction, CtorFromTrxTrytesInvalidTrytes) {
   EXPECT_EQ(t.getBundle(), "");
   EXPECT_EQ(t.getPersistence(), false);
   EXPECT_EQ(t.toTrytes(),
-            "999999999999999999999999999999999999999999999999999999999999999999999999999999999");
+            "99999999999999999999999999999999999999999999999999999999999999999999999999999999999999"
+            "9999999999999999999999999999999999999999999999999");
 }
 
 TEST(Transaction, CtorFull) {
   IOTA::Models::Transaction t("signatureFragments", 1, 2, "nonce", "hash", 3, "trunkTransaction",
-                              "branchTransaction", "address", 4, "bundle", "tag", 5, 6, 7);
+                              "branchTransaction", "address", 4, "bundle", "TAG", 5, 6, 7);
 
   EXPECT_EQ(t.getSignatureFragments(), "signatureFragments");
   EXPECT_EQ(t.getCurrentIndex(), 1);
   EXPECT_EQ(t.getLastIndex(), 2);
   EXPECT_EQ(t.getNonce(), "nonce");
   EXPECT_EQ(t.getHash(), "hash");
-  EXPECT_EQ(t.getTag(), "tag");
-  EXPECT_EQ(t.getObsoleteTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
+  EXPECT_EQ(t.getObsoleteTag(), "TAG");
   EXPECT_EQ(t.getTimestamp(), 3);
   EXPECT_EQ(t.getAttachmentTimestamp(), 5);
   EXPECT_EQ(t.getAttachmentTimestampLowerBound(), 6);
@@ -249,15 +250,15 @@ TEST(Transaction, CtorFull) {
 }
 
 TEST(Transaction, CtorShort) {
-  IOTA::Models::Transaction t = { "address", 1, "tag", 2 };
+  IOTA::Models::Transaction t = { "address", 1, "TAG", 2 };
 
   EXPECT_EQ(t.getSignatureFragments(), "");
   EXPECT_EQ(t.getCurrentIndex(), 0);
   EXPECT_EQ(t.getLastIndex(), 0);
   EXPECT_EQ(t.getNonce(), "");
   EXPECT_EQ(t.getHash(), "");
-  EXPECT_EQ(t.getObsoleteTag(), "tag");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getObsoleteTag(), "TAG");
+  EXPECT_EQ(t.getTag(), "TAG");
   EXPECT_EQ(t.getTimestamp(), 2);
   EXPECT_EQ(t.getAttachmentTimestamp(), 0);
   EXPECT_EQ(t.getAttachmentTimestampLowerBound(), 0);
@@ -271,15 +272,15 @@ TEST(Transaction, CtorShort) {
 }
 
 TEST(Transaction, CtorShortFull) {
-  IOTA::Models::Transaction t = { "address", 1, "tag", 2, 3, 4, 5 };
+  IOTA::Models::Transaction t = { "address", 1, "TAG", 2, 3, 4, 5 };
 
   EXPECT_EQ(t.getSignatureFragments(), "");
   EXPECT_EQ(t.getCurrentIndex(), 0);
   EXPECT_EQ(t.getLastIndex(), 0);
   EXPECT_EQ(t.getNonce(), "");
   EXPECT_EQ(t.getHash(), "");
-  EXPECT_EQ(t.getObsoleteTag(), "tag");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getObsoleteTag(), "TAG");
+  EXPECT_EQ(t.getTag(), "TAG");
   EXPECT_EQ(t.getTimestamp(), 2);
   EXPECT_EQ(t.getAttachmentTimestamp(), 3);
   EXPECT_EQ(t.getAttachmentTimestampLowerBound(), 4);
@@ -295,15 +296,15 @@ TEST(Transaction, CtorShortFull) {
 TEST(Transaction, ConstGetters) {
   const IOTA::Models::Transaction t("signatureFragments", 1, 2, "nonce", "hash", 3,
                                     "trunkTransaction", "branchTransaction", "address", 4, "bundle",
-                                    "tag", 5, 6, 7);
+                                    "TAG", 5, 6, 7);
 
   EXPECT_EQ(t.getSignatureFragments(), "signatureFragments");
   EXPECT_EQ(t.getCurrentIndex(), 1);
   EXPECT_EQ(t.getLastIndex(), 2);
   EXPECT_EQ(t.getNonce(), "nonce");
   EXPECT_EQ(t.getHash(), "hash");
-  EXPECT_EQ(t.getTag(), "tag");
-  EXPECT_EQ(t.getObsoleteTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
+  EXPECT_EQ(t.getObsoleteTag(), "TAG");
   EXPECT_EQ(t.getTimestamp(), 3);
   EXPECT_EQ(t.getAttachmentTimestamp(), 5);
   EXPECT_EQ(t.getAttachmentTimestampLowerBound(), 6);
@@ -384,16 +385,16 @@ TEST(Transaction, TagGetterAndSetter) {
   IOTA::Models::Transaction t;
   EXPECT_EQ(t.getTag(), "");
 
-  t.setTag("tag");
-  EXPECT_EQ(t.getTag(), "tag");
+  t.setTag("TAG");
+  EXPECT_EQ(t.getTag(), "TAG");
 }
 
 TEST(Transaction, ObsoleteTagGetterAndSetter) {
   IOTA::Models::Transaction t;
   EXPECT_EQ(t.getObsoleteTag(), "");
 
-  t.setObsoleteTag("tag");
-  EXPECT_EQ(t.getObsoleteTag(), "tag");
+  t.setObsoleteTag("TAG");
+  EXPECT_EQ(t.getObsoleteTag(), "TAG");
 }
 
 TEST(Transaction, AddressGetterAndSetter) {
@@ -455,11 +456,11 @@ TEST(Transaction, PersistenceGetterAndSetter) {
 TEST(Transaction, OperatorEq) {
   IOTA::Models::Transaction t1("signatureFragments1", 11, 21, "nonce1", "hash1", 31,
                                "trunkTransaction1", "branchTransaction1", "address1", 41, "bundle1",
-                               "tag1", 51, 61, 71);
+                               "TAGONE", 51, 61, 71);
 
   IOTA::Models::Transaction t2("signatureFragments2", 22, 22, "nonce2", "hash2", 32,
                                "trunkTransaction2", "branchTransaction2", "address2", 42, "bundle2",
-                               "tag2", 52, 62, 72);
+                               "TAGTWO", 52, 62, 72);
 
   EXPECT_EQ(t1 == t2, false);
 
@@ -472,11 +473,11 @@ TEST(Transaction, OperatorEq) {
 TEST(Transaction, OperatorNEq) {
   IOTA::Models::Transaction t1("signatureFragments1", 11, 21, "nonce1", "hash1", 31,
                                "trunkTransaction1", "branchTransaction1", "address1", 41, "bundle1",
-                               "tag1", 51, 61, 71);
+                               "TAGONE", 51, 61, 71);
 
   IOTA::Models::Transaction t2("signatureFragments2", 22, 22, "nonce2", "hash2", 32,
                                "trunkTransaction2", "branchTransaction2", "address2", 42, "bundle2",
-                               "tag2", 52, 62, 72);
+                               "TAGTWO", 52, 62, 72);
 
   EXPECT_EQ(t1 != t2, true);
 
@@ -489,7 +490,7 @@ TEST(Transaction, OperatorNEq) {
 TEST(Transaction, IsTailTransaction) {
   IOTA::Models::Transaction t("signatureFragments1", 11, 21, "nonce1", "hash1", 31,
                               "trunkTransaction1", "branchTransaction1", "address1", 41, "bundle1",
-                              "tag1", 51, 61, 71);
+                              "TAGONE", 51, 61, 71);
 
   EXPECT_EQ(t.isTailTransaction(), false);
 

--- a/test/source/models/transaction_test.cpp
+++ b/test/source/models/transaction_test.cpp
@@ -387,6 +387,9 @@ TEST(Transaction, TagGetterAndSetter) {
 
   t.setTag("TAG");
   EXPECT_EQ(t.getTag(), "TAG");
+
+  t.setTag(IOTA::Models::Tag{ "TAGOBJ" });
+  EXPECT_EQ(t.getTag(), "TAGOBJ");
 }
 
 TEST(Transaction, ObsoleteTagGetterAndSetter) {
@@ -395,6 +398,9 @@ TEST(Transaction, ObsoleteTagGetterAndSetter) {
 
   t.setObsoleteTag("TAG");
   EXPECT_EQ(t.getObsoleteTag(), "TAG");
+
+  t.setObsoleteTag(IOTA::Models::Tag{ "TAGOBJ" });
+  EXPECT_EQ(t.getObsoleteTag(), "TAGOBJ");
 }
 
 TEST(Transaction, AddressGetterAndSetter) {

--- a/test/source/models/transfer_test.cpp
+++ b/test/source/models/transfer_test.cpp
@@ -97,6 +97,13 @@ TEST(Transfer, TagGetterAndSetter) {
   EXPECT_EQ(t.getValue(), 1);
   EXPECT_EQ(t.getMessage(), "msg");
   EXPECT_EQ(t.getTag(), "EDITED");
+
+  t.setTag(IOTA::Models::Tag{ "EDITEDOBJ" });
+
+  EXPECT_EQ(t.getAddress(), "addr");
+  EXPECT_EQ(t.getValue(), 1);
+  EXPECT_EQ(t.getMessage(), "msg");
+  EXPECT_EQ(t.getTag(), "EDITEDOBJ");
 }
 
 TEST(Transfer, IsValid) {

--- a/test/source/models/transfer_test.cpp
+++ b/test/source/models/transfer_test.cpp
@@ -38,65 +38,65 @@ TEST(Transfer, CtorDefault) {
 }
 
 TEST(Transfer, CtorShort) {
-  IOTA::Models::Transfer t = { "addr", 1, "msg", "tag" };
+  IOTA::Models::Transfer t = { "addr", 1, "msg", "TAG" };
 
   EXPECT_EQ(t.getAddress(), "addr");
   EXPECT_EQ(t.getValue(), 1);
   EXPECT_EQ(t.getMessage(), "msg");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
 }
 
 TEST(Transfer, ConstGetters) {
-  const IOTA::Models::Transfer t = { "addr", 1, "msg", "tag" };
+  const IOTA::Models::Transfer t = { "addr", 1, "msg", "TAG" };
 
   EXPECT_EQ(t.getAddress(), "addr");
   EXPECT_EQ(t.getValue(), 1);
   EXPECT_EQ(t.getMessage(), "msg");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
 }
 
 TEST(Transfer, AddressGetterAndSetter) {
-  IOTA::Models::Transfer t = { "addr", 1, "msg", "tag" };
+  IOTA::Models::Transfer t = { "addr", 1, "msg", "TAG" };
 
   t.setAddress("edited");
 
   EXPECT_EQ(t.getAddress(), "edited");
   EXPECT_EQ(t.getValue(), 1);
   EXPECT_EQ(t.getMessage(), "msg");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
 }
 
 TEST(Transfer, ValueGetterAndSetter) {
-  IOTA::Models::Transfer t = { "addr", 1, "msg", "tag" };
+  IOTA::Models::Transfer t = { "addr", 1, "msg", "TAG" };
 
   t.setValue(42);
 
   EXPECT_EQ(t.getAddress(), "addr");
   EXPECT_EQ(t.getValue(), 42);
   EXPECT_EQ(t.getMessage(), "msg");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
 }
 
 TEST(Transfer, MessageGetterAndSetter) {
-  IOTA::Models::Transfer t = { "addr", 1, "msg", "tag" };
+  IOTA::Models::Transfer t = { "addr", 1, "msg", "TAG" };
 
   t.setMessage("edited");
 
   EXPECT_EQ(t.getAddress(), "addr");
   EXPECT_EQ(t.getValue(), 1);
   EXPECT_EQ(t.getMessage(), "edited");
-  EXPECT_EQ(t.getTag(), "tag");
+  EXPECT_EQ(t.getTag(), "TAG");
 }
 
 TEST(Transfer, TagGetterAndSetter) {
-  IOTA::Models::Transfer t = { "addr", 1, "msg", "tag" };
+  IOTA::Models::Transfer t = { "addr", 1, "msg", "TAG" };
 
-  t.setTag("edited");
+  t.setTag("EDITED");
 
   EXPECT_EQ(t.getAddress(), "addr");
   EXPECT_EQ(t.getValue(), 1);
   EXPECT_EQ(t.getMessage(), "msg");
-  EXPECT_EQ(t.getTag(), "edited");
+  EXPECT_EQ(t.getTag(), "EDITED");
 }
 
 TEST(Transfer, IsValid) {
@@ -120,23 +120,9 @@ TEST(Transfer, IsValidInvalidMessage) {
   EXPECT_FALSE(t.isValid());
 }
 
-TEST(Transfer, IsValidInvalidTag) {
-  IOTA::Models::Transfer t = { BUNDLE_1_TRX_1_ADDRESS, BUNDLE_1_TRX_1_VALUE, BUNDLE_1_TRX_1_TAG,
-                               "*&7" };
-
-  EXPECT_FALSE(t.isValid());
-}
-
-TEST(Transfer, IsValidInvalidTagLength) {
-  IOTA::Models::Transfer t = { BUNDLE_1_TRX_1_ADDRESS, BUNDLE_1_TRX_1_VALUE, BUNDLE_1_TRX_1_TAG,
-                               "9" };
-
-  EXPECT_FALSE(t.isValid());
-}
-
 TEST(Transfer, EqAndDiffOperators) {
-  IOTA::Models::Transfer t1 = { "addr1", 1, "msg1", "tag1" };
-  IOTA::Models::Transfer t2 = { "addr2", 2, "msg2", "tag2" };
+  IOTA::Models::Transfer t1 = { "addr1", 1, "msg1", "TAGONE" };
+  IOTA::Models::Transfer t2 = { "addr2", 2, "msg2", "TAGTWO" };
 
   EXPECT_EQ(t1 == t2, false);
   EXPECT_EQ(t1 != t2, true);
@@ -156,7 +142,7 @@ TEST(Transfer, EqAndDiffOperators) {
   EXPECT_EQ(t1 == t2, false);
   EXPECT_EQ(t1 != t2, true);
 
-  t2.setTag("tag1");
+  t2.setTag("TAGONE");
 
   EXPECT_EQ(t1 == t2, true);
   EXPECT_EQ(t1 != t2, false);


### PR DESCRIPTION
create Model::Tag and use it in place of Types::Trytes to improve usability. Reduce breaking change on client side by making conversion flexibles. Change code related to tags and simplify tag check code to centralize it in Model::Tag

You can start to review, but please do notmerge yet as I'm still working on adding missing test cases for the added functions.

This will resolve #186 and is part of the global improvement issue #177