### PR TITLE
Trits to bytes coverage

### DIFF
--- a/source/types/trinary.cpp
+++ b/source/types/trinary.cpp
@@ -135,9 +135,9 @@ tritsToBytes(const Trits& trits) {
           data[j] = data[j] + 0xffffffff + carry;
           carry   = data[j] != 0xffffffff;
         }
-        if (!data.back()) {
-          data.pop_back();
-        }
+        // Note: subtracting 1 from the number represented by data would only require to shorten
+        // data if the represented number was 2^(32*k), however, data always represents a multiple
+        // of 3, but 2^n is not divisible by 3 for any n
         break;
     }
   }

--- a/source/types/trinary.cpp
+++ b/source/types/trinary.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <cstdlib>
 #include <functional>
@@ -110,7 +111,11 @@ tritsToBytes(const Trits& trits) {
       data.push_back(static_cast<uint32_t>(sum & 0xffffffff));
     }
     switch (sign * trits[i - 1]) {
-      case 1:
+      case 0: {
+        // nothing to do here
+        break;
+      }
+      case 1: {
         // increment by 1
         for (size_t j = 0; j < data.size(); ++j) {
           data[j] = data[j] + 1;
@@ -128,7 +133,8 @@ tritsToBytes(const Trits& trits) {
           data.push_back(1);
         }
         break;
-      case -1:
+      }
+      case -1: {
         // decrement by 1
         uint8_t carry = 0;
         for (size_t j = 0; j < data.size(); ++j) {
@@ -139,6 +145,12 @@ tritsToBytes(const Trits& trits) {
         // data if the represented number was 2^(32*k), however, data always represents a multiple
         // of 3, but 2^n is not divisible by 3 for any n
         break;
+      }
+      default: {
+        // if we reach here, trits is not valid
+        assert(false);
+        break;
+      }
     }
   }
 

--- a/source/types/trinary.cpp
+++ b/source/types/trinary.cpp
@@ -119,6 +119,12 @@ tritsToBytes(const Trits& trits) {
           }
         }
         if (!data.back()) {
+          // if the 32 most significant bits all got flipped to 0 by the increment (i.e. data
+          // represented 2^(32*k) - 1, where k is the size of data), we need to expand data by the
+          // carry
+          // Note: data always represents a multiple of 3 and since 2^(32*k) - 1 = 4^(16*k) - 1 is
+          // divisible by 3 for any k (by the fact of 4^n - 1 being divisible by 3 for any n), the
+          // carry might be required for any k
           data.push_back(1);
         }
         break;

--- a/test/source/types/trinary_test.cpp
+++ b/test/source/types/trinary_test.cpp
@@ -92,6 +92,11 @@ TEST(Trinary, tritsToBytes) {
   b6.insert(std::begin(b6), IOTA::ByteHashLength - b6.size(), 0x00);
   std::vector<int8_t> b7({ (int8_t)0xb6, (int8_t)0x69, (int8_t)0xfd, (int8_t)0x2e });
   b7.insert(std::begin(b7), IOTA::ByteHashLength - b7.size(), 0xff);
+  std::vector<int8_t> b8({ (int8_t)0x01, (int8_t)0x00, (int8_t)0x00, (int8_t)0x00, (int8_t)0x00 });
+  b8.insert(std::begin(b8), IOTA::ByteHashLength - b8.size(), 0x00);
+  std::vector<int8_t> b9({ (int8_t)0x08, (int8_t)0xff, (int8_t)0xff, (int8_t)0xff, (int8_t)0xff,
+                           (int8_t)0xff, (int8_t)0xff, (int8_t)0xff, (int8_t)0xff });
+  b9.insert(std::begin(b9), IOTA::ByteHashLength - b9.size(), 0x00);
 
   EXPECT_EQ(IOTA::Types::tritsToBytes({}), b0);
   EXPECT_EQ(IOTA::Types::tritsToBytes({ 0 }), b1);
@@ -105,6 +110,13 @@ TEST(Trinary, tritsToBytes) {
   EXPECT_EQ(IOTA::Types::tritsToBytes(
                 { 0, 0, 1, 0, -1, 1, 0, 1, 1, 1, -1, 0, -1, 0, 0, 1, 1, -1, 0, -1 }),
             b7);
+  EXPECT_EQ(IOTA::Types::tritsToBytes(
+                { 1, 1, -1, -1, -1, -1, -1, 0, 0, -1, 1, -1, 0, 0, 1, -1, 1, 0, -1, 1, 1 }),
+            b8);
+  EXPECT_EQ(IOTA::Types::tritsToBytes({ -1, 0,  1, -1, 0, -1, -1, 0,  1,  1,  -1, 1,  1,  -1, 1,
+                                        -1, -1, 1, -1, 1, 1,  1,  -1, -1, 1,  1,  0,  -1, -1, 0,
+                                        0,  -1, 0, 0,  1, 0,  -1, 0,  0,  -1, -1, -1, -1, 1 }),
+            b9);
 }
 
 TEST(Trinary, bytesToTrits) {
@@ -123,6 +135,12 @@ TEST(Trinary, bytesToTrits) {
   t6.insert(std::end(t6), IOTA::TritHashLength - t6.size(), 0x00);
   IOTA::Types::Trits t7({ 0, 0, 1, 0, -1, 1, 0, 1, 1, 1, -1, 0, -1, 0, 0, 1, 1, -1, 0, -1 });
   t7.insert(std::end(t7), IOTA::TritHashLength - t7.size(), 0x00);
+  IOTA::Types::Trits t8({ 1, 1, -1, -1, -1, -1, -1, 0, 0, -1, 1, -1, 0, 0, 1, -1, 1, 0, -1, 1, 1 });
+  t8.insert(std::end(t8), IOTA::TritHashLength - t8.size(), 0x00);
+  IOTA::Types::Trits t9({ -1, 0,  1, -1, 0, -1, -1, 0,  1,  1,  -1, 1,  1,  -1, 1,
+                          -1, -1, 1, -1, 1, 1,  1,  -1, -1, 1,  1,  0,  -1, -1, 0,
+                          0,  -1, 0, 0,  1, 0,  -1, 0,  0,  -1, -1, -1, -1, 1 });
+  t9.insert(std::end(t9), IOTA::TritHashLength - t9.size(), 0x00);
 
   EXPECT_EQ(IOTA::Types::bytesToTrits({}), t0);
   EXPECT_EQ(IOTA::Types::bytesToTrits({ (int8_t)0x00, (int8_t)0x00, (int8_t)0x00, (int8_t)0x00 }),
@@ -139,6 +157,13 @@ TEST(Trinary, bytesToTrits) {
             t6);
   EXPECT_EQ(IOTA::Types::bytesToTrits({ (int8_t)0xb6, (int8_t)0x69, (int8_t)0xfd, (int8_t)0x2e }),
             t7);
+  EXPECT_EQ(IOTA::Types::bytesToTrits(
+                { (int8_t)0x01, (int8_t)0x00, (int8_t)0x00, (int8_t)0x00, (int8_t)0x00 }),
+            t8);
+  EXPECT_EQ(IOTA::Types::bytesToTrits({ (int8_t)0x08, (int8_t)0xff, (int8_t)0xff, (int8_t)0xff,
+                                        (int8_t)0xff, (int8_t)0xff, (int8_t)0xff, (int8_t)0xff,
+                                        (int8_t)0xff }),
+            t9);
 }
 
 TEST(Trinary, TrytesToTrits) {


### PR DESCRIPTION
As promised in Issue #233, this PR adds some testcases that should cover the first conditional code line mentioned in Issue #233. It turns out that the second conditional code line is actually not necessary and therefore removed.