### PR TITLE
configure curl with HTTP_ONLY

### DIFF
--- a/cmake/cpr_settings.cmake
+++ b/cmake/cpr_settings.cmake
@@ -22,11 +22,12 @@
 # SOFTWARE.
 #
 #
-
 ExternalProject_Add("cpr_dep"
                     GIT_SUBMODULES ""
                     CMAKE_ARGS "-DBUILD_CPR_TESTS=OFF"
                     CMAKE_ARGS "-DBUILD_TESTING=0"
+                    CMAKE_ARGS "-DBUILD_CURL_EXE=OFF"
+                    CMAKE_ARGS "-DHTTP_ONLY=ON"
                     CMAKE_ARGS "-DCMAKE_INSTALL_PREFIX=${CMAKE_SOURCE_DIR}/deps"
                     CMAKE_ARGS "-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${CMAKE_SOURCE_DIR}/deps/lib"
                     CMAKE_ARGS "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_SOURCE_DIR}/deps/lib"


### PR DESCRIPTION
Less interesting than I thought, but still small change: enables the HTTP_ONLY curl option.
This results in the a smaller libcurl library (from 516K to 364K on my macbook machine, so not a big deal in my opinion, but I'm not familiar enough with embedded environment to tell if it actually can make a difference).

This requires a change on the cpr CMake. I will make a PR on their side and this can be merged when it is good on cpr side.