### PR TITLE
forward m32 or m64 config to deps

### DIFF
--- a/cmake/compilation_settings.cmake
+++ b/cmake/compilation_settings.cmake
@@ -55,13 +55,3 @@ IF (WIN32)
 ELSE ()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -W -Wall -Wextra -O3")
 ENDIF (WIN32)
-
-########## CLANG SETTINGS ##########
-
-IF (CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-
-########## GNU SETTINGS ##########
-
-ELSEIF (CMAKE_CXX_COMPILER_ID MATCHES "GNU")
-
-endif()

--- a/cmake/cpr_settings.cmake
+++ b/cmake/cpr_settings.cmake
@@ -33,6 +33,8 @@ ExternalProject_Add("cpr_dep"
                     CMAKE_ARGS "-Wno-dev"
                     CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
                     CMAKE_ARGS "-DCMAKE_PREFIX_PATH=${CMAKE_SOURCE_DIR}/deps"
+                    CMAKE_ARGS "-DCMAKE_C_FLAGS=${FORWARD_FLAGS}"
+                    CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${FORWARD_FLAGS}"
                     INSTALL_COMMAND cmake -E echo "Skipping install step."
                     SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/cpr")
 

--- a/cmake/curl_settings.cmake
+++ b/cmake/curl_settings.cmake
@@ -33,6 +33,8 @@ ExternalProject_Add("curl_dep"
                     CMAKE_ARGS "-DCMAKE_LIBRARY_OUTPUT_DIRECTORY=${CMAKE_SOURCE_DIR}/deps/lib"
                     CMAKE_ARGS "-Wno-dev"
                     CMAKE_ARGS "-DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}"
+                    CMAKE_ARGS "-DCMAKE_C_FLAGS=${FORWARD_FLAGS}"
+                    CMAKE_ARGS "-DCMAKE_CXX_FLAGS=${FORWARD_FLAGS}"
                     SOURCE_DIR "${CMAKE_SOURCE_DIR}/external/curl")
 
 include_directories(${CMAKE_SOURCE_DIR}/external/cpr/include)

--- a/cmake/misc.cmake
+++ b/cmake/misc.cmake
@@ -23,7 +23,18 @@
 #
 #
 
-if (NOT ARCH)
+
+if (ARCH MATCHES "32")
+  set(CMAKE_C_FLAGS "-m32 ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-m32 ${CMAKE_CXX_FLAGS}")
+  set(FORWARD_FLAGS "-m32 ${FORWARD_C_FLAGS}")
+
+elseif (ARCH MATCHES "64")
+  set(CMAKE_C_FLAGS "-m64 ${CMAKE_C_FLAGS}")
+  set(CMAKE_CXX_FLAGS "-m64 ${CMAKE_CXX_FLAGS}")
+  set(FORWARD_FLAGS "-m64 ${FORWARD_C_FLAGS}")
+
+else ()
   if (CMAKE_SIZEOF_VOID_P EQUAL 8)
     # 64 bits
     set (ARCH "64")


### PR DESCRIPTION
if you explicitly set -DARCH=32 or -DARCH=64, this will set -m32 flag and forward it to our dependencies.