### PR TITLE
support new references response for getBalances. Deprecate milestone response.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ A [Wiki](https://github.com/thibault-martinez/iota.lib.cpp/wiki) is available an
 
 There's an extensive list of **test cases** on the [test folder](https://github.com/thibault-martinez/iota.lib.cpp/tree/master/test/source) that can be used as reference when developing apps with IOTA.
 
-## Technologies & dependencies
+## Technologies & Dependencies
 
 ### Technologies
 

--- a/include/iota/api/responses/get_balances.hpp
+++ b/include/iota/api/responses/get_balances.hpp
@@ -27,6 +27,7 @@
 
 #include <iota/api/responses/base.hpp>
 #include <iota/types/trytes.hpp>
+#include <iota/utils/deprecated.hpp>
 
 namespace IOTA {
 
@@ -37,10 +38,11 @@ namespace Responses {
 /**
  * GetBalances API call response.
  *
- * Similar to getInclusionStates. It returns the confirmed balance which a list of addresses have
- * at the latest confirmed milestone. In addition to the balances, it also returns the milestone
- * as well as the index with which the confirmed balance was determined. The balances is returned
- * as a list in the same order as the addresses were provided as input.
+ * Returns the confirmed balance, as viewed by tips, in case tips is not supplied, the balance is
+ * based on the latest confirmed milestone. In addition to the balances, it also returns the
+ * referencing tips (or milestone), as well as the index with which the confirmed balance was
+ * determined. The balances is returned as a list in the same order as the addresses were provided
+ * as input.
  *
  * https://iota.readme.io/reference#getbalances
  */
@@ -52,8 +54,18 @@ public:
    * @param milestone The latest confirmed milestone.
    * @param milestoneIndex The latest confirmed milestone index.
    */
-  explicit GetBalances(const std::vector<std::string>& balances = {},
-                       const Types::Trytes& milestone = "", const int64_t& milestoneIndex = 0);
+  DEPRECATED explicit GetBalances(const std::vector<std::string>& balances,
+                                  const Types::Trytes& milestone, const int64_t& milestoneIndex);
+
+  /**
+   * Full init ctor.
+   * @param balances The confirmed balances.
+   * @param references The referencing tips (or milestone)
+   * @param milestoneIndex The latest confirmed milestone index.
+   */
+  explicit GetBalances(const std::vector<std::string>&   balances       = {},
+                       const std::vector<Types::Trytes>& references     = {},
+                       const int64_t&                    milestoneIndex = 0);
 
   /**
    * Json-based ctor.
@@ -93,14 +105,25 @@ public:
 
 public:
   /**
+   * @return referencing tips (or milestone)
+   */
+  const std::vector<Types::Trytes>& getReferences() const;
+
+  /**
+   * @param references referencing tips (or milestone)
+   */
+  void setReferences(const std::vector<Types::Trytes>& references);
+
+public:
+  /**
    * @return milestone.
    */
-  const Types::Trytes& getMilestone() const;
+  DEPRECATED const Types::Trytes& getMilestone() const;
 
   /**
    * @param milestone new milestone for api response.
    */
-  void setMilestone(const Types::Trytes& milestone);
+  DEPRECATED void setMilestone(const Types::Trytes& milestone);
 
 public:
   /**
@@ -118,6 +141,10 @@ private:
    * Confirmed balance in the same order as the addresses were provided as input.
    */
   std::vector<std::string> balances_;
+  /**
+   * referencing tips (or milestone)
+   */
+  std::vector<Types::Trytes> references_;
   /**
    * Latest confirmed milestone.
    */

--- a/include/iota/utils/deprecated.hpp
+++ b/include/iota/utils/deprecated.hpp
@@ -1,0 +1,36 @@
+//
+// MIT License
+//
+// Copyright (c) 2017-2018 Thibault Martinez and Simon Ninon
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+//
+
+//!
+//! https://stackoverflow.com/a/21265197/1939604
+//!
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
+#define DEPRECATED
+#endif

--- a/source/api/responses/get_balances.cpp
+++ b/source/api/responses/get_balances.cpp
@@ -38,6 +38,12 @@ GetBalances::GetBalances(const std::vector<std::string>& balances, const Types::
     : balances_(balances), milestone_(milestone), milestoneIndex_(milestoneIndex) {
 }
 
+GetBalances::GetBalances(const std::vector<std::string>&   balances,
+                         const std::vector<Types::Trytes>& references,
+                         const int64_t&                    milestoneIndex)
+    : balances_(balances), references_(references), milestoneIndex_(milestoneIndex) {
+}
+
 GetBalances::GetBalances(const json& res) {
   deserialize(res);
 }
@@ -48,6 +54,10 @@ GetBalances::deserialize(const json& res) {
 
   if (res.count("balances")) {
     balances_ = res.at("balances").get<std::vector<std::string>>();
+  }
+
+  if (res.count("references")) {
+    references_ = res.at("references").get<std::vector<Types::Trytes>>();
   }
 
   if (res.count("milestone")) {
@@ -72,6 +82,16 @@ GetBalances::getBalances() {
 void
 GetBalances::setBalances(const std::vector<std::string>& balances) {
   balances_ = balances;
+}
+
+const std::vector<Types::Trytes>&
+GetBalances::getReferences() const {
+  return references_;
+}
+
+void
+GetBalances::setReferences(const std::vector<Types::Trytes>& references) {
+  references_ = references;
 }
 
 const Types::Trytes&

--- a/test/source/api/responses/get_balances_test.cpp
+++ b/test/source/api/responses/get_balances_test.cpp
@@ -32,71 +32,123 @@ TEST(GetBalancesReponse, DefaultCtorShouldInitFields) {
   const IOTA::API::Responses::GetBalances res;
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>());
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>());
   EXPECT_EQ(res.getMilestone(), "");
   EXPECT_EQ(res.getMilestoneIndex(), 0);
   EXPECT_EQ(res.getDuration(), 0);
 }
 
 TEST(GetBalancesReponse, CtorShouldInitFields) {
-  const IOTA::API::Responses::GetBalances res{ { "bal1", "bal2", "bal3" }, "milestone", 1 };
+  const IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                               std::vector<std::string>({ "ref" }), 1 };
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3" }));
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "ref" }));
+  EXPECT_EQ(res.getMilestone(), "");
+  EXPECT_EQ(res.getMilestoneIndex(), 1);
+  EXPECT_EQ(res.getDuration(), 0);
+}
+
+TEST(GetBalancesReponse, DeprecatedCtorShouldInitFields) {
+  const IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                               "milestone", 1 };
+
+  EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3" }));
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({}));
   EXPECT_EQ(res.getMilestone(), "milestone");
   EXPECT_EQ(res.getMilestoneIndex(), 1);
   EXPECT_EQ(res.getDuration(), 0);
 }
 
 TEST(GetBalancesReponse, AssignementOperator) {
-  const IOTA::API::Responses::GetBalances res1{ { "bal1", "bal2", "bal3" }, "milestone", 1 };
-  IOTA::API::Responses::GetBalances       res2;
+  const IOTA::API::Responses::GetBalances res1{
+    std::vector<std::string>({ "bal1", "bal2", "bal3" }), std::vector<std::string>({ "ref" }), 1
+  };
+  IOTA::API::Responses::GetBalances res2;
 
   res2 = res1;
   EXPECT_EQ(res1.getBalances(), res2.getBalances());
+  EXPECT_EQ(res1.getReferences(), res2.getReferences());
+  EXPECT_EQ(res1.getMilestone(), res2.getMilestone());
+  EXPECT_EQ(res1.getMilestoneIndex(), res2.getMilestoneIndex());
+  EXPECT_EQ(res1.getDuration(), res2.getDuration());
+}
+
+TEST(GetBalancesReponse, DeprecatedCtorAssignementOperator) {
+  const IOTA::API::Responses::GetBalances res1{
+    std::vector<std::string>({ "bal1", "bal2", "bal3" }), "milestone", 1
+  };
+  IOTA::API::Responses::GetBalances res2;
+
+  res2 = res1;
+  EXPECT_EQ(res1.getBalances(), res2.getBalances());
+  EXPECT_EQ(res1.getReferences(), res2.getReferences());
   EXPECT_EQ(res1.getMilestone(), res2.getMilestone());
   EXPECT_EQ(res1.getMilestoneIndex(), res2.getMilestoneIndex());
   EXPECT_EQ(res1.getDuration(), res2.getDuration());
 }
 
 TEST(GetBalancesReponse, GetBalancesNonConst) {
-  IOTA::API::Responses::GetBalances res{ { "bal1", "bal2", "bal3" }, "milestone", 1 };
+  IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                         std::vector<std::string>({ "ref" }), 1 };
 
   res.getBalances().push_back("bal4");
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3", "bal4" }));
-  EXPECT_EQ(res.getMilestone(), "milestone");
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "ref" }));
+  EXPECT_EQ(res.getMilestone(), "");
   EXPECT_EQ(res.getMilestoneIndex(), 1);
   EXPECT_EQ(res.getDuration(), 0);
 }
 
 TEST(GetBalancesReponse, SetBalances) {
-  IOTA::API::Responses::GetBalances res{ { "bal1", "bal2", "bal3" }, "milestone", 1 };
+  IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                         std::vector<std::string>({ "ref" }), 1 };
 
   res.setBalances({ "bal1", "bal2", "bal3", "bal4" });
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3", "bal4" }));
-  EXPECT_EQ(res.getMilestone(), "milestone");
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "ref" }));
+  EXPECT_EQ(res.getMilestone(), "");
   EXPECT_EQ(res.getMilestoneIndex(), 1);
   EXPECT_EQ(res.getDuration(), 0);
 }
 
 TEST(GetBalancesReponse, SetMilestone) {
-  IOTA::API::Responses::GetBalances res{ { "bal1", "bal2", "bal3" }, "milestone", 1 };
+  IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                         std::vector<std::string>({ "ref" }), 1 };
 
-  res.setMilestone("newmilestone");
+  res.setMilestone({ "newmilestone" });
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3" }));
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "ref" }));
   EXPECT_EQ(res.getMilestone(), "newmilestone");
   EXPECT_EQ(res.getMilestoneIndex(), 1);
   EXPECT_EQ(res.getDuration(), 0);
 }
 
+TEST(GetBalancesReponse, SetReferences) {
+  IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                         std::vector<std::string>({ "ref" }), 1 };
+
+  res.setReferences({ "newref" });
+
+  EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3" }));
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "newref" }));
+  EXPECT_EQ(res.getMilestone(), "");
+  EXPECT_EQ(res.getMilestoneIndex(), 1);
+  EXPECT_EQ(res.getDuration(), 0);
+}
+
 TEST(GetBalancesReponse, SetMilestoneIndex) {
-  IOTA::API::Responses::GetBalances res{ { "bal1", "bal2", "bal3" }, "milestone", 1 };
+  IOTA::API::Responses::GetBalances res{ std::vector<std::string>({ "bal1", "bal2", "bal3" }),
+                                         std::vector<std::string>({ "ref" }), 1 };
 
   res.setMilestoneIndex(42);
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3" }));
-  EXPECT_EQ(res.getMilestone(), "milestone");
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "ref" }));
+  EXPECT_EQ(res.getMilestone(), "");
   EXPECT_EQ(res.getMilestoneIndex(), 42);
   EXPECT_EQ(res.getDuration(), 0);
 }
@@ -106,12 +158,14 @@ TEST(GetBalancesReponse, DeserializeShouldSetFields) {
   json                              data;
 
   data["balances"]       = std::vector<std::string>({ "bal1", "bal2", "bal3" });
+  data["references"]     = std::vector<std::string>({ "ref" });
   data["milestone"]      = "milestone";
   data["milestoneIndex"] = 1;
 
   res.deserialize(data);
 
   EXPECT_EQ(res.getBalances(), std::vector<std::string>({ "bal1", "bal2", "bal3" }));
+  EXPECT_EQ(res.getReferences(), std::vector<std::string>({ "ref" }));
   EXPECT_EQ(res.getMilestone(), "milestone");
   EXPECT_EQ(res.getMilestoneIndex(), 1);
   EXPECT_EQ(res.getDuration(), 0);


### PR DESCRIPTION
As mentioned in #283, getBalances now returns a trytes array "references" instead of the trytes string "milestone".

I added support for this new response element and deprecated the old milestone related functions.

I initially removed the support for milestone, but I finally decided to keep it.
The reason is that it is dependent on the IRI version. If some nodes are not using the latest IRI version, then the milestone will still be returned in place of the references.
Deprecation should be a good enough first move, we can then clean up in a future release.
Let me know if you prefer to drop support now though.