### PR TITLE
Bump IRI to 1.5.0

### DIFF
--- a/test/source/api/core/attach_to_tangle_test.cpp
+++ b/test/source/api/core/attach_to_tangle_test.cpp
@@ -42,7 +42,7 @@ TEST(Core, AttachToTangleRemotePowOneTx) {
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b[0].toTrytes();
-  auto tta = api.getTransactionsToApprove(27);
+  auto tta = api.getTransactionsToApprove(3);
   auto att =
       api.attachToTangle(tta.getTrunkTransaction(), tta.getBranchTransaction(), POW_LEVEL, { tx });
   auto trytes = att.getTrytes()[0];
@@ -58,7 +58,7 @@ TEST(Core, AttachToTangleLocalPowOneTx) {
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b[0].toTrytes();
-  auto tta = api.getTransactionsToApprove(27);
+  auto tta = api.getTransactionsToApprove(3);
   auto att =
       api.attachToTangle(tta.getTrunkTransaction(), tta.getBranchTransaction(), POW_LEVEL, { tx });
   auto trytes = att.getTrytes()[0];
@@ -80,7 +80,7 @@ TEST(Core, AttachToTangleRemotePowManyTx) {
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b[0].toTrytes();
-  auto tta = api.getTransactionsToApprove(27);
+  auto tta = api.getTransactionsToApprove(3);
   auto att =
       api.attachToTangle(tta.getTrunkTransaction(), tta.getBranchTransaction(), POW_LEVEL, { tx });
   auto trytes = att.getTrytes()[0];
@@ -102,7 +102,7 @@ TEST(Core, AttachToTangleLocalPowManyTx) {
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx  = b[0].toTrytes();
-  auto tta = api.getTransactionsToApprove(27);
+  auto tta = api.getTransactionsToApprove(3);
   auto att =
       api.attachToTangle(tta.getTrunkTransaction(), tta.getBranchTransaction(), POW_LEVEL, { tx });
   auto trytes = att.getTrytes()[0];

--- a/test/source/api/core/get_transactions_to_approve_test.cpp
+++ b/test/source/api/core/get_transactions_to_approve_test.cpp
@@ -33,7 +33,7 @@
 
 TEST(Core, GetTransactionsToApprove) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port());
-  auto            res = api.getTransactionsToApprove(27);
+  auto            res = api.getTransactionsToApprove(3);
 
   EXPECT_GE(res.getDuration(), 0);
   EXPECT_TRUE(IOTA::Types::isValidHash(res.getTrunkTransaction()));
@@ -42,7 +42,7 @@ TEST(Core, GetTransactionsToApprove) {
 
 TEST(Core, GetTransactionsToApproveWithReference) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port());
-  auto            res = api.getTransactionsToApprove(27, BUNDLE_1_TRX_1_HASH);
+  auto            res = api.getTransactionsToApprove(3, "");
 
   EXPECT_GE(res.getDuration(), 0);
   EXPECT_TRUE(IOTA::Types::isValidHash(res.getTrunkTransaction()));
@@ -52,6 +52,6 @@ TEST(Core, GetTransactionsToApproveWithReference) {
 TEST(Core, GetTransactionsToApproveInvalidReference) {
   IOTA::API::Core api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_EXCEPTION(auto res = api.getTransactionsToApprove(27, "ref");
+  EXPECT_EXCEPTION(auto res = api.getTransactionsToApprove(3, "ref");
                    , IOTA::Errors::BadRequest, "Invalid reference input")
 }

--- a/test/source/api/extended/is_reattachable_test.cpp
+++ b/test/source/api/extended/is_reattachable_test.cpp
@@ -49,7 +49,7 @@ TEST(Extended, IsReattachable) {
   IOTA::Models::Address input = { ACCOUNT_5_ADDRESS_1_HASH, ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs, ACCOUNT_5_ADDRESS_1_HASH);
+  api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs, ACCOUNT_5_ADDRESS_1_HASH);
 
   EXPECT_EQ(api.isReattachable({ unconfirmedTransactionAddr, noFundAddress,
                                  confirmedTransactionAddr, fundAddress }),

--- a/test/source/api/extended/replay_bundle_test.cpp
+++ b/test/source/api/extended/replay_bundle_test.cpp
@@ -36,7 +36,7 @@
 TEST(Extended, ReplayBundle) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port(), true, 380);
 
-  auto res = api.replayBundle(BUNDLE_5_TRX_1_HASH, 27, POW_LEVEL);
+  auto res = api.replayBundle(BUNDLE_5_TRX_1_HASH, 3, POW_LEVEL);
 
   ASSERT_EQ(res.getSuccessfully().size(), 1UL);
   ASSERT_EQ(res.getSuccessfully(), std::vector<bool>({ true }));
@@ -45,20 +45,20 @@ TEST(Extended, ReplayBundle) {
 TEST(Extended, ReplayBundleNonTailTransaction) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_EXCEPTION(api.replayBundle(BUNDLE_1_TRX_4_HASH, 27, POW_LEVEL), IOTA::Errors::IllegalState,
+  EXPECT_EXCEPTION(api.replayBundle(BUNDLE_1_TRX_4_HASH, 3, POW_LEVEL), IOTA::Errors::IllegalState,
                    "Invalid tail transaction supplied.");
 }
 
 TEST(Extended, ReplayBundleBundleHash) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_EXCEPTION(api.replayBundle(BUNDLE_1_HASH, 27, POW_LEVEL), IOTA::Errors::IllegalState,
+  EXPECT_EXCEPTION(api.replayBundle(BUNDLE_1_HASH, 3, POW_LEVEL), IOTA::Errors::IllegalState,
                    "Invalid transaction supplied.");
 }
 
 TEST(Extended, ReplayBundleInvalidHash) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_EXCEPTION(api.replayBundle("hello", 27, POW_LEVEL), IOTA::Errors::IllegalState,
+  EXPECT_EXCEPTION(api.replayBundle("hello", 3, POW_LEVEL), IOTA::Errors::IllegalState,
                    "Invalid transaction supplied.");
 }

--- a/test/source/api/extended/send_transfer_test.cpp
+++ b/test/source/api/extended/send_transfer_test.cpp
@@ -47,7 +47,7 @@ TEST(Extended, SendTransfer) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                               ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM);
 
   ASSERT_EQ(res.getSuccessfully().size(), 4UL);
@@ -65,7 +65,7 @@ TEST(Extended, SendTransferNoMessage) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                               ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM);
 
   ASSERT_EQ(res.getSuccessfully().size(), 4UL);
@@ -82,7 +82,7 @@ TEST(Extended, SendTransferInvalidTransferAddress) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                                     ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM),
                    IOTA::Errors::IllegalState, "Invalid Transfer");
 }
@@ -99,7 +99,7 @@ TEST(Extended, SendTransferNotEnoughFund) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                                     ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM),
                    IOTA::Errors::IllegalState, "Not enough balance");
 }
@@ -115,7 +115,7 @@ TEST(Extended, SendTransferZeroTransfer) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                               ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM);
 
   ASSERT_EQ(res.getSuccessfully().size(), 1UL);
@@ -133,7 +133,7 @@ TEST(Extended, SendTransferInvalidRemainderAddress) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs, "invalid__"),
+  EXPECT_EXCEPTION(api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs, "invalid__"),
                    IOTA::Errors::IllegalState, "address has invalid length");
 }
 
@@ -146,7 +146,7 @@ TEST(Extended, SendTransferNoInput) {
 
   std::vector<IOTA::Models::Address> inputs = {};
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                               ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM);
 
   ASSERT_EQ(res.getSuccessfully().size(), 4UL);
@@ -164,7 +164,7 @@ TEST(Extended, SendTransferNoRemainderAddress) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs, "");
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs, "");
 
   ASSERT_EQ(res.getSuccessfully().size(), 4UL);
   EXPECT_EQ(res.getSuccessfully(), std::vector<bool>({ true, true, true, true }));
@@ -181,7 +181,7 @@ TEST(Extended, SendTransferSecurity) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 3 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                               ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM);
 
   ASSERT_EQ(res.getSuccessfully().size(), 5UL);
@@ -225,7 +225,7 @@ TEST(Extended, SendTransferLongMessage) {
                                   ACCOUNT_5_ADDRESS_1_FUND, 0, 2 };
   std::vector<IOTA::Models::Address> inputs = { input };
 
-  auto res = api.sendTransfer(ACCOUNT_5_SEED, 27, POW_LEVEL, transfers, inputs,
+  auto res = api.sendTransfer(ACCOUNT_5_SEED, 3, POW_LEVEL, transfers, inputs,
                               ACCOUNT_5_ADDRESS_1_HASH_WITHOUT_CHECKSUM);
 
   ASSERT_EQ(res.getSuccessfully().size(), 5UL);

--- a/test/source/api/extended/send_trytes_test.cpp
+++ b/test/source/api/extended/send_trytes_test.cpp
@@ -36,20 +36,20 @@
 TEST(Extended, SendTrytesNothing) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_NO_THROW(api.sendTrytes({}, 27, POW_LEVEL));
+  EXPECT_NO_THROW(api.sendTrytes({}, 3, POW_LEVEL));
 }
 
 TEST(Extended, SendTrytesEmpty) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_EXCEPTION(api.sendTrytes({ "" }, 27, POW_LEVEL), IOTA::Errors::IllegalState,
+  EXPECT_EXCEPTION(api.sendTrytes({ "" }, 3, POW_LEVEL), IOTA::Errors::IllegalState,
                    "Invalid transaction trytes");
 }
 
 TEST(Extended, SendTrytesInvalidTrytes) {
   IOTA::API::Extended api(get_proxy_host(), get_proxy_port());
 
-  EXPECT_EXCEPTION(api.sendTrytes({ "INVALIDTRYTES" }, 27, POW_LEVEL), IOTA::Errors::IllegalState,
+  EXPECT_EXCEPTION(api.sendTrytes({ "INVALIDTRYTES" }, 3, POW_LEVEL), IOTA::Errors::IllegalState,
                    "Invalid transaction trytes");
 }
 
@@ -62,7 +62,7 @@ TEST(Extended, SendTrytesOne) {
   b.finalize();
   b.addTrytes({ EMPTY_SIGNATURE_FRAGMENT });
   auto tx = b[0].toTrytes();
-  EXPECT_NO_THROW(api.sendTrytes({ tx }, 27, POW_LEVEL));
+  EXPECT_NO_THROW(api.sendTrytes({ tx }, 3, POW_LEVEL));
 }
 
 TEST(Extended, SendTrytesMulti) {
@@ -83,5 +83,5 @@ TEST(Extended, SendTrytesMulti) {
   auto tx1 = b[1].toTrytes();
   auto tx2 = b[2].toTrytes();
   auto tx3 = b[3].toTrytes();
-  EXPECT_NO_THROW(api.sendTrytes({ tx0, tx1, tx2, tx3 }, 27, POW_LEVEL));
+  EXPECT_NO_THROW(api.sendTrytes({ tx0, tx1, tx2, tx3 }, 3, POW_LEVEL));
 }

--- a/test/testnet/scripts/iri_setup.sh
+++ b/test/testnet/scripts/iri_setup.sh
@@ -27,11 +27,11 @@
 
 git clone https://github.com/iotaledger/iri.git test/testnet/iri
 cd test/testnet/iri
-git checkout f575913 # dev branch
+git checkout 937cb404 # dev branch
 cp ../iri_config/Snapshot.txt src/main/resources
 cp ../iri_config/iri.ini .
 mvn clean compile -q
 mvn package -q
 cp -r ../testnetdb .
-java -jar target/iri-1.4.2.4.jar --testnet --testnet-no-coo-validation --snapshot=src/main/resources/Snapshot.txt -p 14265 --mwm 1 -c iri.ini 1> /dev/null &
+java -jar target/iri-1.5.0.jar --testnet --testnet-no-coo-validation --snapshot=src/main/resources/Snapshot.txt -p 14265 --mwm 1 -c iri.ini 1> /dev/null &
 cd -

--- a/test/testnet/scripts/iri_setup_windows.sh
+++ b/test/testnet/scripts/iri_setup_windows.sh
@@ -27,7 +27,7 @@
 
 git clone https://github.com/iotaledger/iri.git test/testnet/iri
 cd test/testnet/iri
-git checkout f575913 # dev branch
+git checkout 937cb404 # dev branch
 cp ../iri_config/Snapshot.txt src/main/resources
 cp ../iri_config/iri.ini.windows iri.ini
 mvn clean compile


### PR DESCRIPTION
This bumps testnet IRI version to 1.5.0.
However, this does not fix the failing build related to java configuration.