### PR TITLE
fix issue 316

### DIFF
--- a/source/api/extended.cpp
+++ b/source/api/extended.cpp
@@ -741,7 +741,7 @@ Extended::getAccountData(const Models::Seed& seed, int start, int end, bool incl
   const auto transfers = bundlesFromAddresses(addresses.getAddresses(), inclusionStates);
   const auto balances  = getBalancesAndFormat(addresses.getAddresses(), threshold);
 
-  return { addresses.getAddresses(), transfers, balances.getTotalBalance(),
+  return { balances.getInputs(), transfers, balances.getTotalBalance(),
            stopWatch.getElapsedTime().count() };
 }
 

--- a/source/api/extended.cpp
+++ b/source/api/extended.cpp
@@ -737,11 +737,29 @@ Extended::getAccountData(const Models::Seed& seed, int start, int end, bool incl
                          long threshold) const {
   const Utils::StopWatch stopWatch;
 
-  const auto addresses = getNewAddresses(seed, start, end - start, true);
-  const auto transfers = bundlesFromAddresses(addresses.getAddresses(), inclusionStates);
-  const auto balances  = getBalancesAndFormat(addresses.getAddresses(), threshold);
+  auto addresses              = getNewAddresses(seed, start, end - start, true).getAddresses();
+  const auto transfers        = bundlesFromAddresses(addresses, inclusionStates);
+  const auto balances         = getBalancesAndFormat(addresses, threshold);
+  const auto updatedAddresses = balances.getInputs();
 
-  return { balances.getInputs(), transfers, balances.getTotalBalance(),
+  //! addresses returned by getNewAddresses do not contain the balance information
+  //! getBalancesAndFormat get the balances but:
+  //!  * it only returns addresses with positive balance
+  //!  * it does not update the input addresses
+  //!
+  //! this loop goes through the getBalancesAndFormat result to update the balance
+  //! of addresses returned by getNewAddresses before returning them.
+  for (size_t i = 0, j = 0; i < updatedAddresses.size(); ++i) {
+    while (j < addresses.size() && updatedAddresses[i] != addresses[j]) {
+      ++j;
+    }
+
+    if (j < addresses.size()) {
+      addresses[j].setBalance(updatedAddresses[i].getBalance());
+    }
+  }
+
+  return { addresses, transfers, balances.getTotalBalance(),
            stopWatch.getElapsedTime().count() };
 }
 

--- a/test/source/api/extended/get_account_data_test.cpp
+++ b/test/source/api/extended/get_account_data_test.cpp
@@ -42,6 +42,13 @@ TEST(Extended, GetAccountData) {
                 { ACCOUNT_2_ADDRESS_1_HASH, ACCOUNT_2_ADDRESS_2_HASH, ACCOUNT_2_ADDRESS_3_HASH,
                   ACCOUNT_2_ADDRESS_4_HASH, ACCOUNT_2_ADDRESS_5_HASH, ACCOUNT_2_ADDRESS_6_HASH }));
 
+  EXPECT_EQ(res.getAddresses()[0].getBalance(), ACCOUNT_2_ADDRESS_1_FUND);
+  EXPECT_EQ(res.getAddresses()[1].getBalance(), ACCOUNT_2_ADDRESS_2_FUND);
+  EXPECT_EQ(res.getAddresses()[2].getBalance(), ACCOUNT_2_ADDRESS_3_FUND);
+  EXPECT_EQ(res.getAddresses()[3].getBalance(), ACCOUNT_2_ADDRESS_4_FUND);
+  EXPECT_EQ(res.getAddresses()[4].getBalance(), ACCOUNT_2_ADDRESS_5_FUND);
+  EXPECT_EQ(res.getAddresses()[5].getBalance(), ACCOUNT_2_ADDRESS_6_FUND);
+
   std::vector<IOTA::Models::Bundle> expectedBundleRes;
 
   expectedBundleRes.push_back(
@@ -77,6 +84,9 @@ TEST(Extended, GetAccountDataStartEnd) {
 
   EXPECT_EQ(res.getAddresses(), std::vector<IOTA::Models::Address>(
                                     { ACCOUNT_2_ADDRESS_2_HASH, ACCOUNT_2_ADDRESS_3_HASH }));
+
+  EXPECT_EQ(res.getAddresses()[0].getBalance(), ACCOUNT_2_ADDRESS_2_FUND);
+  EXPECT_EQ(res.getAddresses()[1].getBalance(), ACCOUNT_2_ADDRESS_3_FUND);
 
   EXPECT_FALSE(res.getTransfers().empty());
   EXPECT_EQ(res.getBalance(), ACCOUNT_2_ADDRESS_2_FUND + ACCOUNT_2_ADDRESS_3_FUND);


### PR DESCRIPTION
This aims to fix #316.

getAccountData returns the right addresses and the right total balance for the given seed.
However, if you check the balance of each address, each of them will be 0.

The reason is that getBalancesAndFormat does not update the input addresses returned by getNewAddresses, but returns a copy of these addresses.

I limited the change to just getAccountData to avoid any possible side effect, and we can take more time to decide whether we can improve the current design of this part.

I added some test cases. I could not run them locally as I have some issues to build IRI on my computer right now. If it does not pass on Travis and I could not fix the IRI install on my side, I will switch to my previous computer.
