### PR TITLE
make wereAddressesSpentFrom protected

### DIFF
--- a/include/iota/api/core.hpp
+++ b/include/iota/api/core.hpp
@@ -253,18 +253,6 @@ public:
    */
   Responses::Base storeTransactions(const std::vector<Types::Trytes>& trytes) const;
 
-  /**
-   * Check if a list of addresses was ever spent from, in the current epoch, or in previous epochs.
-   *
-   * https://iota.readme.io/reference#wereaddressesspentfrom
-   *
-   * @param addresses List of addresses you want to check if they were spent from.
-   *
-   * @return The response.
-   */
-  Responses::WereAddressesSpentFrom wereAddressesSpentFrom(
-      const std::vector<Models::Address>& addresses) const;
-
   /*
    * Used to ensure tail resolves to a consistent ledger which is necessary to validate before
    * attempting promotion. Checks transaction hashes for promotability.
@@ -280,6 +268,25 @@ public:
    * @return The response.
    */
   Responses::CheckConsistency checkConsistency(const std::vector<Types::Trytes>& tails) const;
+
+protected:
+    /**
+     * Check if a list of addresses was ever spent from, in the current epoch, or in previous epochs.
+     *
+     * https://iota.readme.io/reference#wereaddressesspentfrom
+     *
+     * From iota.lib.js:
+     * `wereAddressesSpentFrom` command is a temporary measure to prevent loss of funds,
+     * when security assumptions are ignored by developers or wallet users.
+     * It's being used internally by `getNewAddress()`.
+     * Avoid developing programs that rely on this method.
+     *
+     * @param addresses List of addresses you want to check if they were spent from.
+     *
+     * @return The response.
+     */
+    Responses::WereAddressesSpentFrom wereAddressesSpentFrom(
+        const std::vector<Models::Address>& addresses) const;
 
 private:
   /**

--- a/test/source/api/core/were_addresses_spent_from_test.cpp
+++ b/test/source/api/core/were_addresses_spent_from_test.cpp
@@ -31,8 +31,19 @@
 #include <test/utils/constants.hpp>
 #include <test/utils/expect_exception.hpp>
 
+class TestWereAddressesSpentFrom : public IOTA::API::Core {
+public:
+  TestWereAddressesSpentFrom(const std::string& host, int port)
+      : IOTA::API::Core(host, port) {}
+
+  IOTA::API::Responses::WereAddressesSpentFrom wereAddressesSpentFrom(
+      const std::vector<IOTA::Models::Address>& addresses) const {
+        return IOTA::API::Core::wereAddressesSpentFrom(addresses);
+      }
+};
+
 TEST(Core, WereAddressesSpentFromOneTrue) {
-  IOTA::API::Core api(get_proxy_host(), get_proxy_port());
+  TestWereAddressesSpentFrom api(get_proxy_host(), get_proxy_port());
 
   auto res = api.wereAddressesSpentFrom({ ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM });
 
@@ -40,7 +51,7 @@ TEST(Core, WereAddressesSpentFromOneTrue) {
 }
 
 TEST(Core, WereAddressesSpentFromOneFalse) {
-  IOTA::API::Core api(get_proxy_host(), get_proxy_port());
+  TestWereAddressesSpentFrom api(get_proxy_host(), get_proxy_port());
 
   auto res = api.wereAddressesSpentFrom({ ACCOUNT_1_ADDRESS_1_HASH_WITHOUT_CHECKSUM });
 
@@ -48,7 +59,7 @@ TEST(Core, WereAddressesSpentFromOneFalse) {
 }
 
 TEST(Core, WereAddressesSpentFromMany) {
-  IOTA::API::Core api(get_proxy_host(), get_proxy_port());
+  TestWereAddressesSpentFrom api(get_proxy_host(), get_proxy_port());
 
   auto res = api.wereAddressesSpentFrom(
       { ACCOUNT_1_ADDRESS_1_HASH_WITHOUT_CHECKSUM, ACCOUNT_2_ADDRESS_1_HASH_WITHOUT_CHECKSUM,
@@ -58,7 +69,7 @@ TEST(Core, WereAddressesSpentFromMany) {
 }
 
 TEST(Core, WereAddressesSpentFromEmpty) {
-  IOTA::API::Core api(get_proxy_host(), get_proxy_port());
+  TestWereAddressesSpentFrom api(get_proxy_host(), get_proxy_port());
 
   EXPECT_EXCEPTION(auto res = api.wereAddressesSpentFrom({});
                    , IOTA::Errors::BadRequest, "Invalid parameters")


### PR DESCRIPTION
# What is the purpose of your code change?
#312 iota.lib.js stopped exporting wereAddressesSpentFrom.
As a consequence, I moved it to protected.

I checked, right now iota.lib.js still uses it for:
* getNewAddress
* getAccountData

On our library, we already use it for getNewAddress.

For getAccountData, this is not the case yet.
From my understand, iota.lib.js returns an additional parameter inputs for which wereAddressesSpentFrom is used to determine which one are valid input or not.

Would also be consistent to use it in getInputs, which is planned for iota.lib.js but not done yet.

Will update this PR with the changes in getAccountData and getInputs (though, let me know if you have some feedback regarding that before I go forward with the implementation).


# Resources links
[iota.lib.js getAccountData](https://github.com/iotaledger/iota.js/blob/next/packages/core/src/createGetAccountData.ts)
[iota.lib.js getNewAddress](https://github.com/iotaledger/iota.js/blob/next/packages/core/src/createGetNewAddress.ts)

