### PR TITLE
This commit enables the use of the thetangle.org load balancer

### DIFF
--- a/include/iota/constants.hpp
+++ b/include/iota/constants.hpp
@@ -65,6 +65,6 @@ constexpr int TrinaryBase                                 = 3;
 constexpr int GetBalancesRecommandedConfirmationThreshold = 100;
 
 //! IRI API version
-const std::string APIVersion = "1.2.0";
+const std::string APIVersion = "1";
 
 }  // namespace IOTA


### PR DESCRIPTION
Use of https://nodes.thetangle.org:443 with the library was not possible. The issue was analyzed by @nmeylan. This might be only a temporary fix.

As discussed with @thibault-martinez....