### PR TITLE
API::Core::attachToTangle recompute TX hashes for local POW

### DIFF
--- a/include/iota/constants.hpp
+++ b/include/iota/constants.hpp
@@ -65,6 +65,6 @@ constexpr int TrinaryBase                                 = 3;
 constexpr int GetBalancesRecommandedConfirmationThreshold = 100;
 
 //! IRI API version
-const std::string APIVersion = "1.2.0";
+const std::string APIVersion = "1";
 
 }  // namespace IOTA

--- a/source/api/core.cpp
+++ b/source/api/core.cpp
@@ -54,6 +54,7 @@
 #include <iota/api/responses/remove_neighbors.hpp>
 #include <iota/api/responses/were_addresses_spent_from.hpp>
 #include <iota/crypto/pow.hpp>
+#include <iota/crypto/curl.hpp>
 #include <iota/errors/illegal_state.hpp>
 #include <iota/models/neighbor.hpp>
 #include <iota/models/transaction.hpp>
@@ -161,6 +162,13 @@ Core::attachToTangle(const Types::Trytes& trunkTransaction, const Types::Trytes&
         tx.setTag(tx.getObsoleteTag());
       }
 
+      auto transactionTrits = Types::trytesToTrits(tx.toTrytes());
+      auto updatedhash = Types::Trits(TritHashLength);
+      Crypto::Curl curl;
+      curl.absorb(transactionTrits);
+      curl.squeeze(updatedhash);
+      tx.setHash(Types::tritsToTrytes(updatedhash));
+      
       resultTrytes.emplace_back(tx.toTrytes());
       prevTx = tx.getHash();
     }


### PR DESCRIPTION
API::Core::attachToTangle: Recompute transaction hashes in bundle after manipulation in the case of local POW.

When using local POW, the creation of bundles was faulty. The transactions were manipulated and the TX hashes were not updated. This lead to invalid bundles.

This solves issue https://github.com/thibault-martinez/iota.lib.cpp/issues/326